### PR TITLE
feat: Add MRU (Most Recently Used) app cycling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ The Core module is imported via `#if canImport(ShortcutCycleCore)` for compatibi
 ### Key Algorithms
 
 - **App cycling:** Deterministic algorithm in `AppCyclingLogic` — priority order: HUD selection > frontmost app > last active > first in group. Handles wrap-around.
+- **MRU ordering:** `AppCyclingLogic.sortedByMRU` reorders HUD items by most recently used. Tracks plain bundle IDs (not composite). Updates only on finalization (modifier release / click), not during intermediate cycling. Persisted in `AppGroup.mruOrder`, managed by `GroupStore.updateMRUOrder`.
 - **Multi-instance apps:** Composite ID format `"{bundleId}-{pid}"` to distinguish browser profiles and multiple windows.
 - **GFS backup retention:** Keep all < 1h, 1/hour for 1-24h, 1/day for 1-30d, 1/week for 30d+, cap at 100 backups.
 - **Debounced auto-backup:** 60s timer, duplicate detection via content comparison, flushes on app termination.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ ShortcutCycle helps you switch between your favorite apps with just one keyboard
 
 - **Group Apps**: Put related apps together (e.g., \"Browsers\" for Chrome, Safari, Edge; or \"Messaging\" for Slack, Discord, Messages).
 - **One Key Magic**: Press your global shortcut to cycle through apps in the group. Press it again to switch to the next one.
+- **Smart Order**: Apps are automatically ordered by most recently used — the app you want is always one tap away, just like macOS's Command+Tab.
 - **Press and Hold**: Hold the shortcut to see the HUD without switching immediately, just like macOS's native Command+Tab behavior.
 - **Multi-Profile Support**: Apps with multiple instances (like Firefox profiles) are shown separately and can be cycled through individually.
 - **See What's Happening**: A beautiful, native-looking HUD overlay shows you which app is active and what's coming up next.

--- a/ShortcutCycle/CHANGELOG.md
+++ b/ShortcutCycle/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [1.4] - 2026-02-12
 
 ### Added
+- **MRU Cycling**: Apps in each group are now ordered by Most Recently Used, matching macOS Cmd+Tab behavior. The most recently used app is always one tap away. MRU order updates only when you finalize your selection (release modifiers or click), not during intermediate cycling steps.
 - **Press and Hold**: Added support for "Press and Hold" behavior to match macOS Command+Tab. Hold the shortcut to view the HUD; tap quickly to switch blindly.
 - **In-App Keyboard Shortcuts**: Added macOS menu bar commands with keyboard shortcuts when the settings window is open. Includes tab switching (Cmd+1/2), add/delete group (Cmd+N, Cmd+Delete with confirmation), group navigation (Cmd+Up/Down, Cmd+[/], Cmd+K/J), and sidebar toggle (Cmd+Ctrl+S).
 - **Language Picker**: Language picker now shows both the system-language name and the native name (e.g. "German / Deutsch") for easier identification.

--- a/ShortcutCycle/ShortcutCycle/Models/GroupStore.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/GroupStore.swift
@@ -141,7 +141,21 @@ public class GroupStore: ObservableObject {
             saveGroups()
         }
     }
-    
+
+    public func updateMRUOrder(activatedBundleId: String, for groupId: UUID) {
+        guard let index = groups.firstIndex(where: { $0.id == groupId }) else { return }
+        let validBundleIds = Set(groups[index].apps.map { $0.bundleIdentifier })
+        let newOrder = AppCyclingLogic.updatedMRUOrder(
+            currentOrder: groups[index].mruOrder,
+            activatedBundleId: activatedBundleId,
+            validBundleIds: validBundleIds
+        )
+        if groups[index].mruOrder != newOrder {
+            groups[index].mruOrder = newOrder
+            saveGroups()
+        }
+    }
+
     // MARK: - Persistence
     
     private func saveGroups() {

--- a/ShortcutCycle/ShortcutCycleTests/AppGroupTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/AppGroupTests.swift
@@ -302,7 +302,7 @@ final class AppGroupTests: XCTestCase {
     }
 
     func testDecodingWithoutOptionalFields() throws {
-        // Simulate legacy data without openAppIfNeeded
+        // Simulate legacy data without openAppIfNeeded or mruOrder
         let json = """
         {
             "id": "\(UUID().uuidString)",
@@ -319,6 +319,20 @@ final class AppGroupTests: XCTestCase {
         XCTAssertNil(decoded.openAppIfNeeded)
         XCTAssertFalse(decoded.shouldOpenAppIfNeeded)
         XCTAssertNil(decoded.lastActiveAppBundleId)
+        XCTAssertNil(decoded.mruOrder)
+    }
+
+    func testCodableRoundTripWithMRUOrder() throws {
+        let group = AppGroup(
+            name: "MRU Test",
+            apps: [AppItem(bundleIdentifier: "com.a", name: "A")],
+            mruOrder: ["com.a", "com.b"]
+        )
+
+        let data = try JSONEncoder().encode(group)
+        let decoded = try JSONDecoder().decode(AppGroup.self, from: data)
+
+        XCTAssertEqual(decoded.mruOrder, ["com.a", "com.b"])
     }
 
     // MARK: - Equatable


### PR DESCRIPTION
## Summary

- Apps in each group are now ordered by Most Recently Used, matching macOS Cmd+Tab behavior — the most recently used app is always one tap away
- MRU order updates only on finalization (modifier release or click), not during intermediate cycling steps, preventing order corruption like [D,C,B,A]
- Fully backward compatible: `mruOrder` is optional (nil = fixed group order), old exports/data decode without issues, no settings version bump needed

## Changes

**Core logic** (`AppGroup.swift`, `GroupStore.swift`):
- Added `mruOrder: [String]?` property to `AppGroup` (tracks plain bundle IDs, not composite)
- Added `AppCyclingLogic.sortedByMRU` — reorders items by MRU with group-order fallback
- Added `AppCyclingLogic.updatedMRUOrder` — moves activated app to front, filters stale entries
- Added `GroupStore.updateMRUOrder` — persists MRU order, saves only if changed

**HUD finalization** (`HUDManager.swift`):
- Added `onFinalize` callback that fires once when user releases modifiers or clicks (with double-fire guard)

**Wiring** (`AppSwitcher.swift`):
- `getHUDItems` applies MRU sort after building items (both cycling modes)
- All `showHUD` paths pass `onFinalize` callback to update MRU
- Blind-switch (no HUD) paths update MRU directly

**Tests** (20 new tests):
- 12 in `AppCyclingLogicTests` (sorting + update logic)
- 7 in `GroupStoreTests` (persistence, stale filtering, export/import round-trip)
- 1 new + 1 updated in `AppGroupTests` (backward compat, Codable round-trip)

**Docs**: Updated CHANGELOG.md, CLAUDE.md, README.md

## Test plan

- [x] `swift test` — all 240 tests pass, 0 failures
- [x] Manual: create a group with 4+ apps, cycle through them, verify MRU order changes after finalizing
- [ ] Manual: verify intermediate cycling (hold modifier, tap through A→B→C→D) doesn't corrupt MRU order
- [ ] Manual: verify old settings exports import correctly (mruOrder = nil)

🤖 Generated with [Claude Code](https://claude.com/claude-code)