### PR TITLE
Fix Desktop Space jump when Settings window is on a different Space

### DIFF
--- a/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
@@ -133,9 +133,21 @@ class HUDManager: @preconcurrency ObservableObject {
         
         // Activate our app so we can receive local events when running under AppKit.
         if let app = NSApp {
+            // Before activating, order out any ShortcutCycle windows that live on a
+            // different Space. If we call activate() while a window (e.g. Settings) is
+            // on another Space, macOS jumps to that Space before switching to the target
+            // app. orderOut hides the window without destroying it, so the user can
+            // re-open Settings normally from the menu bar.
+            app.windows.forEach { win in
+                if win !== self.window && win.isVisible && !win.isOnActiveSpace {
+                    win.orderOut(nil)
+                }
+            }
+
             app.activate(ignoringOtherApps: true)
 
-            // Fix for "Splash" issue:
+            // Fix for "Splash" issue: push any remaining same-Space windows behind
+            // the HUD after activation.
             DispatchQueue.main.async {
                 app.windows.forEach { win in
                     if win !== self.window && win.isVisible {


### PR DESCRIPTION
## Summary

Fixes #31

When a user triggers a group shortcut with the Settings window open on a different Desktop Space, macOS was jumping to that Space before switching to the target app.

**Root cause:** `HUDManager.scheduleShow` calls `NSApp.activate(ignoringOtherApps: true)` so it can receive local key events for the HUD. When a ShortcutCycle window (Settings) lives on another Space at the time of activation, macOS associates the activation with that Space and jumps there first.

**Fix:** Before calling `activate()`, synchronously call `orderOut(nil)` on any ShortcutCycle windows that are on a different Space (`win.isOnActiveSpace == false`). `orderOut` removes the window from the screen without destroying it — the user can re-open Settings normally from the menu bar at any time.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Settings closed, shortcut pressed | ✅ No Space jump | ✅ No Space jump |
| Settings open on same Space, shortcut pressed | ✅ No Space jump | ✅ No Space jump |
| Settings open on different Space, shortcut pressed | ❌ Jumps to Settings Space first | ✅ Stays on current Space |
| After shortcut, re-open Settings from menu bar | — | ✅ Opens normally |

## Test plan

- [ ] `cd ShortcutCycle && swift test` — all tests pass
- [ ] Open Settings, drag it to a different Desktop Space, trigger a group shortcut → verify no Space jump
- [ ] After the above, open Settings again from the menu bar → verify it opens normally
- [ ] Trigger a shortcut with Settings closed → verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)