### PR TITLE
[codex] Fix Cycling Mode layout in narrow group editor

### DIFF
--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -87,30 +87,31 @@ struct GroupEditView: View {
                             }
                     }
 
-                    Text("Cycling Mode".localized(language: selectedLanguage))
-                        .font(.caption.weight(.medium))
-                        .foregroundColor(.secondary)
-                        .padding(.top, 4)
+                    HStack {
+                        Text("Cycling Mode".localized(language: selectedLanguage))
+                            .font(.caption.weight(.medium))
+                            .foregroundColor(.secondary)
 
-                    ViewThatFits(in: .horizontal) {
-                        Picker("Cycling Mode".localized(language: selectedLanguage), selection: cyclingModeSelection) {
-                            Text("Running apps only".localized(language: selectedLanguage)).tag(false)
-                            Text("All apps (open if needed)".localized(language: selectedLanguage)).tag(true)
-                        }
-                        .pickerStyle(.segmented)
-                        .font(.caption)
-                        .labelsHidden()
-                        .fixedSize(horizontal: true, vertical: false)
+                        ViewThatFits(in: .horizontal) {
+                            Picker("Cycling Mode".localized(language: selectedLanguage), selection: cyclingModeSelection) {
+                                Text("Running apps only".localized(language: selectedLanguage)).tag(false)
+                                Text("All apps (open if needed)".localized(language: selectedLanguage)).tag(true)
+                            }
+                            .pickerStyle(.segmented)
+                            .font(.caption)
+                            .labelsHidden()
+                            .fixedSize(horizontal: true, vertical: false)
 
-                        Picker("Cycling Mode".localized(language: selectedLanguage), selection: cyclingModeSelection) {
-                            Text("Running apps only".localized(language: selectedLanguage)).tag(false)
-                            Text("All apps (open if needed)".localized(language: selectedLanguage)).tag(true)
+                            Picker("Cycling Mode".localized(language: selectedLanguage), selection: cyclingModeSelection) {
+                                Text("Running apps only".localized(language: selectedLanguage)).tag(false)
+                                Text("All apps (open if needed)".localized(language: selectedLanguage)).tag(true)
+                            }
+                            .pickerStyle(.menu)
+                            .font(.caption)
+                            .labelsHidden()
                         }
-                        .pickerStyle(.menu)
-                        .font(.caption)
-                        .labelsHidden()
                     }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 4)
 
                     Text(cyclingModeHelpText)
                     .font(.caption)

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -20,6 +20,26 @@ struct GroupEditView: View {
     private var group: AppGroup? {
         store.groups.first { $0.id == groupId }
     }
+
+    private var cyclingModeSelection: Binding<Bool> {
+        Binding(
+            get: { group?.shouldOpenAppIfNeeded ?? false },
+            set: { newValue in
+                DispatchQueue.main.async {
+                    guard var updatedGroup = group else { return }
+                    updatedGroup.openAppIfNeeded = newValue
+                    store.updateGroup(updatedGroup)
+                }
+            }
+        )
+    }
+
+    private var cyclingModeHelpText: String {
+        guard let group else { return "" }
+        return group.shouldOpenAppIfNeeded
+            ? "Cycle through all apps in the group. Non-running apps will be launched when selected.".localized(language: selectedLanguage)
+            : "Cycle through running apps only. If no app is running, the first app in the group will be launched.".localized(language: selectedLanguage)
+    }
     
     var body: some View {
         ScrollView {
@@ -66,28 +86,33 @@ struct GroupEditView: View {
                                 ShortcutManager.shared.registerAllShortcuts()
                             }
                     }
-                    
-                    Picker("Cycling Mode".localized(language: selectedLanguage), selection: Binding(
-                        get: { group.shouldOpenAppIfNeeded },
-                        set: { newValue in
-                            DispatchQueue.main.async {
-                                var updatedGroup = group
-                                updatedGroup.openAppIfNeeded = newValue
-                                store.updateGroup(updatedGroup)
-                            }
-                        }
-                    )) {
-                        Text("Running apps only".localized(language: selectedLanguage)).tag(false)
-                        Text("All apps (open if needed)".localized(language: selectedLanguage)).tag(true)
-                    }
-                    .pickerStyle(.segmented)
-                    .font(.caption)
-                    .padding(.top, 4)
 
-                    Text(group.shouldOpenAppIfNeeded
-                        ? "Cycle through all apps in the group. Non-running apps will be launched when selected.".localized(language: selectedLanguage)
-                        : "Cycle through running apps only. If no app is running, the first app in the group will be launched.".localized(language: selectedLanguage)
-                    )
+                    Text("Cycling Mode".localized(language: selectedLanguage))
+                        .font(.caption.weight(.medium))
+                        .foregroundColor(.secondary)
+                        .padding(.top, 4)
+
+                    ViewThatFits(in: .horizontal) {
+                        Picker("Cycling Mode".localized(language: selectedLanguage), selection: cyclingModeSelection) {
+                            Text("Running apps only".localized(language: selectedLanguage)).tag(false)
+                            Text("All apps (open if needed)".localized(language: selectedLanguage)).tag(true)
+                        }
+                        .pickerStyle(.segmented)
+                        .font(.caption)
+                        .labelsHidden()
+                        .fixedSize(horizontal: true, vertical: false)
+
+                        Picker("Cycling Mode".localized(language: selectedLanguage), selection: cyclingModeSelection) {
+                            Text("Running apps only".localized(language: selectedLanguage)).tag(false)
+                            Text("All apps (open if needed)".localized(language: selectedLanguage)).tag(true)
+                        }
+                        .pickerStyle(.menu)
+                        .font(.caption)
+                        .labelsHidden()
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Text(cyclingModeHelpText)
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .padding(.top, 2)

--- a/ShortcutCycle/ShortcutCycleTests/GroupEditViewTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/GroupEditViewTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+import AppKit
+import SwiftUI
+#if canImport(ShortcutCycleCore)
+@testable import ShortcutCycleCore
+#endif
+@testable import ShortcutCycle
+
+@MainActor
+final class GroupEditViewTests: XCTestCase {
+
+    private var userDefaults: UserDefaults!
+    private var store: GroupStore!
+    private var window: NSWindow?
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+
+        suiteName = "GroupEditViewTests-\(UUID().uuidString)"
+        userDefaults = UserDefaults(suiteName: suiteName)
+        userDefaults.removePersistentDomain(forName: suiteName)
+        store = GroupStore(userDefaults: userDefaults)
+    }
+
+    override func tearDown() {
+        window?.orderOut(nil)
+        window = nil
+
+        if let suiteName {
+            userDefaults?.removePersistentDomain(forName: suiteName)
+        }
+
+        store = nil
+        userDefaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testCyclingModeUsesSegmentedControlWhenEditorIsWide() throws {
+        let hostingView = hostGroupEditView(width: 720)
+
+        XCTAssertNotNil(
+            findSubview(ofType: NSSegmentedControl.self, in: hostingView),
+            "Wide layouts should keep the Cycling Mode control segmented."
+        )
+    }
+
+    func testCyclingModeFallsBackFromSegmentedControlWhenEditorIsNarrow() throws {
+        let hostingView = hostGroupEditView(width: 320)
+
+        XCTAssertNil(
+            findSubview(ofType: NSSegmentedControl.self, in: hostingView),
+            "Narrow layouts should avoid rendering the Cycling Mode control as a segmented control."
+        )
+        XCTAssertNotNil(
+            findSubview(ofType: NSPopUpButton.self, in: hostingView),
+            "Narrow layouts should still render a usable Cycling Mode picker."
+        )
+    }
+
+    private func hostGroupEditView(width: CGFloat, height: CGFloat = 600) -> NSHostingView<AnyView> {
+        let groupId = try! XCTUnwrap(store.groups.first?.id)
+        let rootView = AnyView(
+            GroupEditView(groupId: groupId)
+                .environmentObject(store)
+                .frame(width: width, height: height)
+        )
+        let hostingView = NSHostingView(rootView: rootView)
+        let frame = NSRect(x: 0, y: 0, width: width, height: height)
+        window = NSWindow(
+            contentRect: frame,
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window?.contentView = hostingView
+        window?.layoutIfNeeded()
+        hostingView.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        return hostingView
+    }
+
+    private func findSubview<ViewType: NSView>(ofType type: ViewType.Type, in root: NSView) -> ViewType? {
+        if let match = root as? ViewType {
+            return match
+        }
+
+        for subview in root.subviews {
+            if let match = findSubview(ofType: type, in: subview) {
+                return match
+            }
+        }
+
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary
- make the Groups editor switch the Cycling Mode control from segmented to a compact menu when the detail pane gets too narrow
- keep the Cycling Mode label and helper copy stable while reusing one binding for both presentations
- add a regression test that hosts the real SwiftUI view and asserts wide layouts stay segmented while narrow layouts fall back cleanly

## Why
The Cycling Mode segmented control was allowed to compress indefinitely inside the flexible Groups settings split view. At narrow widths, that let the segmented labels collapse into an awkward, low-quality layout instead of switching to a control that still fits.

## Testing
- `swift test`

Fixes #36
