### PR TITLE
Suggest shortcut ideas for unassigned groups

### DIFF
--- a/ShortcutCycle/Package.swift
+++ b/ShortcutCycle/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
                 "GroupStore.swift",
                 "HUDAppItem.swift",
                 "HUDItemFilter.swift",
+                "ShortcutSuggestion.swift",
                 "SettingsExport.swift",
                 "KeyboardShortcutsNames.swift",
                 "URLCommandFileValidation.swift",

--- a/ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj
+++ b/ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		DF88A3B52F300CB20042E749 /* URLScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3B72F300CB20042E749 /* URLScheme.swift */; };
 		DF88A3B92F300CB20042E749 /* HUDItemFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3B82F300CB20042E749 /* HUDItemFilter.swift */; };
 		DF88A3BA2F300CB20042E749 /* HUDItemFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3B82F300CB20042E749 /* HUDItemFilter.swift */; };
+		A1B200022F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */; };
+		A1B200032F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */; };
 		DF88A3C22F300CE00042E749 /* WelcomeBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3C02F300CE00042E749 /* WelcomeBannerView.swift */; };
 		DF88A3C32F300CE00042E749 /* WelcomeBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3C02F300CE00042E749 /* WelcomeBannerView.swift */; };
 		E1F4B0012F40000100C0DE01 /* URLCommandFileValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F4B0032F40000100C0DE01 /* URLCommandFileValidation.swift */; };
@@ -140,6 +142,7 @@
 		DF88A3AF2F300CB10042E749 /* BackupBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupBrowserView.swift; sourceTree = "<group>"; };
 		DF88A3B72F300CB20042E749 /* URLScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLScheme.swift; sourceTree = "<group>"; };
 		DF88A3B82F300CB20042E749 /* HUDItemFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDItemFilter.swift; sourceTree = "<group>"; };
+		A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutSuggestion.swift; sourceTree = "<group>"; };
 		DF88A3C02F300CE00042E749 /* WelcomeBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeBannerView.swift; sourceTree = "<group>"; };
 		DF8B47D72F2F090100C473F8 /* ShortcutCycleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShortcutCycleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1F4B0032F40000100C0DE01 /* URLCommandFileValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCommandFileValidation.swift; sourceTree = "<group>"; };
@@ -207,6 +210,7 @@
 				DF88A33B2F300B110042E749 /* GroupStore.swift */,
 				DF88A33C2F300B110042E749 /* HUDAppItem.swift */,
 				DF88A3B82F300CB20042E749 /* HUDItemFilter.swift */,
+				A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */,
 				DF88A33D2F300B110042E749 /* KeyboardShortcutsNames.swift */,
 				DF88A33E2F300B110042E749 /* SettingsExport.swift */,
 				E1F4B0032F40000100C0DE01 /* URLCommandFileValidation.swift */,
@@ -523,6 +527,7 @@
 				DF88A3912F300C640042E749 /* HUDPreviewView.swift in Sources */,
 				DF88A39A2F300C800042E749 /* HUDAppItem.swift in Sources */,
 				DF88A3B92F300CB20042E749 /* HUDItemFilter.swift in Sources */,
+				A1B200022F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */,
 				DF88A39B2F300C800042E749 /* SettingsExport.swift in Sources */,
 				DF88A39C2F300C800042E749 /* AppGroup.swift in Sources */,
 				DF88A3A62F300CA00042E749 /* LaunchAtLoginManager.swift in Sources */,
@@ -579,6 +584,7 @@
 				DF88A3822F300B110042E749 /* AppSwitcher.swift in Sources */,
 				DF88A3832F300B110042E749 /* HUDAppItem.swift in Sources */,
 				DF88A3BA2F300CB20042E749 /* HUDItemFilter.swift in Sources */,
+				A1B200032F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */,
 				DF88A3842F300B110042E749 /* AppItem.swift in Sources */,
 				DF88A3852F300B110042E749 /* LaunchAtLoginManager.swift in Sources */,
 				DF88A3862F300B110042E749 /* MenuBarView.swift in Sources */,

--- a/ShortcutCycle/ShortcutCycle/Models/ShortcutSuggestion.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/ShortcutSuggestion.swift
@@ -1,0 +1,35 @@
+import Foundation
+import KeyboardShortcuts
+
+public enum ShortcutSuggestions {
+    @MainActor
+    public static func available(
+        for groups: [AppGroup],
+        excluding groupID: UUID,
+        limit: Int = 3
+    ) -> [KeyboardShortcuts.Shortcut] {
+        guard limit > 0 else { return [] }
+
+        let candidates: [KeyboardShortcuts.Shortcut] = [
+            .init(.one, modifiers: [.option]),
+            .init(.two, modifiers: [.option]),
+            .init(.three, modifiers: [.option]),
+            .init(.four, modifiers: [.option]),
+            .init(.five, modifiers: [.option]),
+            .init(.six, modifiers: [.option]),
+            .init(.seven, modifiers: [.option]),
+            .init(.eight, modifiers: [.option]),
+            .init(.nine, modifiers: [.option])
+        ]
+
+        let takenShortcuts = groups.compactMap { group -> KeyboardShortcuts.Shortcut? in
+            guard group.id != groupID else { return nil }
+            return KeyboardShortcuts.getShortcut(for: group.shortcutName)
+        }
+
+        return candidates
+            .filter { candidate in !takenShortcuts.contains(candidate) }
+            .prefix(limit)
+            .map { $0 }
+    }
+}

--- a/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
@@ -103,6 +103,7 @@
 "Running apps only" = "التطبيقات المشغلة فقط";
 "All apps (open if needed)" = "جميع التطبيقات (فتح إذا لزم الأمر)";
 "Displays the keyboard shortcut used to trigger the switch." = "يعرض اختصار لوحة المفاتيح المستخدم لتشغيل التبديل.";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "جرّب نمطًا بسيطًا مثل ⌥1 و⌥2 و⌥3.";
 "Opening…" = "جارٍ الفتح…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "التنقل بين جميع التطبيقات في المجموعة. سيتم فتح التطبيقات غير المشغلة عند اختيارها.";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "التنقل بين التطبيقات المشغلة فقط. إذا لم يكن أي تطبيق مشغلاً، سيتم فتح أول تطبيق في المجموعة.";

--- a/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
@@ -102,6 +102,7 @@
 "Running apps only" = "Nur laufende Apps";
 "All apps (open if needed)" = "Alle Apps (bei Bedarf öffnen)";
 "Displays the keyboard shortcut used to trigger the switch." = "Zeigt das Tastenkürzel an, das zum Auslösen des Wechsels verwendet wird.";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "Versuche ein einfaches Schema wie ⌥1, ⌥2 und ⌥3.";
 "Opening…" = "Wird geöffnet…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "Alle Apps in der Gruppe durchlaufen. Nicht laufende Apps werden beim Auswählen geöffnet.";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "Nur laufende Apps durchlaufen. Wenn keine App läuft, wird die erste App der Gruppe geöffnet.";

--- a/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
@@ -104,6 +104,7 @@
 "Running apps only" = "Running apps only";
 "All apps (open if needed)" = "All apps (open if needed)";
 "Displays the keyboard shortcut used to trigger the switch." = "Displays the keyboard shortcut used to trigger the switch.";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "Try a simple pattern like ⌥1, ⌥2, and ⌥3.";
 "Opening…" = "Opening…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "Cycle through all apps in the group. Non-running apps will be launched when selected.";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "Cycle through running apps only. If no app is running, the first app in the group will be launched.";

--- a/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
@@ -102,6 +102,7 @@
 "Running apps only" = "Solo apps en ejecución";
 "All apps (open if needed)" = "Todas las apps (abrir si es necesario)";
 "Displays the keyboard shortcut used to trigger the switch." = "Muestra el atajo de teclado usado para activar el cambio.";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "Prueba un patrón simple como ⌥1, ⌥2 y ⌥3.";
 "Opening…" = "Abriendo…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "Alternar entre todas las apps del grupo. Las apps que no estén en ejecución se abrirán al seleccionarlas.";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "Alternar solo entre apps en ejecución. Si ninguna app está abierta, se abrirá la primera app del grupo.";

--- a/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
@@ -102,6 +102,7 @@
 "Running apps only" = "Apps en cours uniquement";
 "All apps (open if needed)" = "Toutes les apps (ouvrir si nécessaire)";
 "Displays the keyboard shortcut used to trigger the switch." = "Affiche le raccourci clavier utilisé pour déclencher le changement.";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "Essayez un schéma simple comme ⌥1, ⌥2 et ⌥3.";
 "Opening…" = "Ouverture…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "Parcourir toutes les apps du groupe. Les apps non lancées seront ouvertes lors de la sélection.";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "Parcourir uniquement les apps en cours. Si aucune app n'est ouverte, la première app du groupe sera lancée.";

--- a/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
@@ -102,6 +102,7 @@
 "Running apps only" = "Solo app in esecuzione";
 "All apps (open if needed)" = "Tutte le app (apri se necessario)";
 "Displays the keyboard shortcut used to trigger the switch." = "Mostra la scorciatoia da tastiera usata per attivare il cambio.";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "Prova uno schema semplice come ⌥1, ⌥2 e ⌥3.";
 "Opening…" = "Apertura…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "Scorri tutte le app del gruppo. Le app non in esecuzione verranno avviate quando selezionate.";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "Scorri solo le app in esecuzione. Se nessuna app è aperta, verrà avviata la prima app del gruppo.";

--- a/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
@@ -102,6 +102,7 @@
 "Running apps only" = "実行中のアプリのみ";
 "All apps (open if needed)" = "すべてのアプリ（必要に応じて開く）";
 "Displays the keyboard shortcut used to trigger the switch." = "切り替えに使用するキーボードショートカットを表示します。";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "⌥1、⌥2、⌥3 のようなシンプルなパターンを試してください。";
 "Opening…" = "起動中…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "グループ内のすべてのアプリを循環します。実行中でないアプリは選択時に起動されます。";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "実行中のアプリのみを循環します。アプリが起動していない場合、グループの最初のアプリが起動されます。";

--- a/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
@@ -102,6 +102,7 @@
 "Running apps only" = "실행 중인 앱만";
 "All apps (open if needed)" = "모든 앱 (필요시 열기)";
 "Displays the keyboard shortcut used to trigger the switch." = "전환을 트리거하는 데 사용되는 키보드 단축키를 표시합니다.";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "⌥1, ⌥2, ⌥3 같은 간단한 패턴을 사용해 보세요.";
 "Opening…" = "여는 중…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "그룹의 모든 앱을 순환합니다. 실행 중이 아닌 앱은 선택 시 실행됩니다.";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "실행 중인 앱만 순환합니다. 실행 중인 앱이 없으면 그룹의 첫 번째 앱이 실행됩니다.";

--- a/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
@@ -102,6 +102,7 @@
 "Running apps only" = "Alleen actieve apps";
 "All apps (open if needed)" = "Alle apps (openen indien nodig)";
 "Displays the keyboard shortcut used to trigger the switch." = "Toont de sneltoets die wordt gebruikt om te schakelen.";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "Probeer een eenvoudig patroon zoals ⌥1, ⌥2 en ⌥3.";
 "Opening…" = "Openen…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "Alle apps in de groep doorlopen. Niet-actieve apps worden geopend bij selectie.";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "Alleen actieve apps doorlopen. Als geen app actief is, wordt de eerste app van de groep geopend.";

--- a/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
@@ -102,6 +102,7 @@
 "Running apps only" = "Tylko uruchomione aplikacje";
 "All apps (open if needed)" = "Wszystkie aplikacje (otwórz jeśli potrzeba)";
 "Displays the keyboard shortcut used to trigger the switch." = "Wyświetla skrót klawiszowy używany do przełączania.";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "Wypróbuj prosty schemat, taki jak ⌥1, ⌥2 i ⌥3.";
 "Opening…" = "Otwieranie…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "Przełączaj wszystkie aplikacje w grupie. Nieuruchomione aplikacje zostaną otwarte po wybraniu.";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "Przełączaj tylko uruchomione aplikacje. Jeśli żadna aplikacja nie jest uruchomiona, pierwsza aplikacja z grupy zostanie otwarta.";

--- a/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
@@ -102,6 +102,7 @@
 "Running apps only" = "Apenas apps em execução";
 "All apps (open if needed)" = "Todos os apps (abrir se necessário)";
 "Displays the keyboard shortcut used to trigger the switch." = "Exibe o atalho de teclado usado para acionar a troca.";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "Experimente um padrão simples como ⌥1, ⌥2 e ⌥3.";
 "Opening…" = "Abrindo…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "Alternar entre todos os apps do grupo. Apps não abertos serão iniciados ao selecionar.";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "Alternar apenas entre apps em execução. Se nenhum app estiver aberto, o primeiro app do grupo será iniciado.";

--- a/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
@@ -102,6 +102,7 @@
 "Running apps only" = "Только запущенные приложения";
 "All apps (open if needed)" = "Все приложения (открыть при необходимости)";
 "Displays the keyboard shortcut used to trigger the switch." = "Отображает сочетание клавиш для переключения.";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "Попробуйте простую схему, например ⌥1, ⌥2 и ⌥3.";
 "Opening…" = "Открытие…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "Переключаться между всеми приложениями группы. Незапущенные приложения будут открыты при выборе.";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "Переключаться только между запущенными приложениями. Если ни одно приложение не запущено, будет открыто первое приложение группы.";

--- a/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
@@ -102,6 +102,7 @@
 "Running apps only" = "Yalnızca çalışan uygulamalar";
 "All apps (open if needed)" = "Tüm uygulamalar (gerekirse aç)";
 "Displays the keyboard shortcut used to trigger the switch." = "Geçişi tetiklemek için kullanılan klavye kısayolunu gösterir.";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "⌥1, ⌥2 ve ⌥3 gibi basit bir düzen deneyin.";
 "Opening…" = "Açılıyor…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "Gruptaki tüm uygulamalarda gezin. Çalışmayan uygulamalar seçildiğinde açılır.";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "Yalnızca çalışan uygulamalarda gezin. Hiçbir uygulama çalışmıyorsa gruptaki ilk uygulama açılır.";

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
@@ -103,6 +103,7 @@
 "Running apps only" = "仅运行中的应用";
 "All apps (open if needed)" = "所有应用（必要时打开）";
 "Displays the keyboard shortcut used to trigger the switch." = "显示用于触发切换的键盘快捷键。";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "试试像 ⌥1、⌥2 和 ⌥3 这样简单的模式。";
 "Opening…" = "正在打开…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "循环组内所有应用。未运行的应用在选中时将被启动。";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "仅循环运行中的应用。如果没有应用在运行，将启动组内的第一个应用。";

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
@@ -104,6 +104,7 @@
 "Running apps only" = "僅執行中的應用程式";
 "All apps (open if needed)" = "所有應用程式（必要時開啟）";
 "Displays the keyboard shortcut used to trigger the switch." = "顯示用於觸發切換的鍵盤快捷鍵。";
+"Try a simple pattern like ⌥1, ⌥2, and ⌥3." = "試試像 ⌥1、⌥2 和 ⌥3 這樣簡單的模式。";
 "Opening…" = "正在開啟…";
 "Cycle through all apps in the group. Non-running apps will be launched when selected." = "循環群組內所有應用程式。未執行的應用程式在選取時將被啟動。";
 "Cycle through running apps only. If no app is running, the first app in the group will be launched." = "僅循環執行中的應用程式。如果沒有應用程式在執行，將啟動群組內的第一個應用程式。";

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -160,7 +160,7 @@ private struct GroupShortcutEditor: View {
     let groupId: UUID
 
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
-    @State private var assignedShortcut: KeyboardShortcuts.Shortcut?
+    @State private var shortcutRefreshToken = 0
 
     private var shortcutName: KeyboardShortcuts.Name {
         .forGroup(groupId)
@@ -175,7 +175,7 @@ private struct GroupShortcutEditor: View {
     }
 
     private var shouldShowSuggestions: Bool {
-        assignedShortcut == nil && !suggestionShortcuts.isEmpty
+        currentShortcut == nil && !suggestionShortcuts.isEmpty
     }
 
     var body: some View {
@@ -186,7 +186,6 @@ private struct GroupShortcutEditor: View {
             VStack(alignment: .leading, spacing: 8) {
                 KeyboardShortcuts.Recorder(for: shortcutName)
                     .onChange(of: currentShortcut) { _, _ in
-                        syncAssignedShortcut()
                         ShortcutManager.shared.registerAllShortcuts()
                     }
 
@@ -223,26 +222,12 @@ private struct GroupShortcutEditor: View {
             .foregroundColor(.secondary)
             .padding(.top, 2)
         }
-        .onAppear {
-            syncAssignedShortcut()
-        }
-        .onChange(of: groupId) { _, _ in
-            syncAssignedShortcut()
-        }
-        .onChange(of: store.groups) { _, _ in
-            syncAssignedShortcut()
-        }
-    }
-
-    @MainActor
-    private func syncAssignedShortcut() {
-        assignedShortcut = currentShortcut
     }
 
     @MainActor
     private func assignShortcut(_ shortcut: KeyboardShortcuts.Shortcut) {
         KeyboardShortcuts.setShortcut(shortcut, for: shortcutName)
-        assignedShortcut = shortcut
+        shortcutRefreshToken += 1
         ShortcutManager.shared.registerAllShortcuts()
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -184,10 +184,7 @@ private struct GroupShortcutEditor: View {
                 .font(.headline)
 
             VStack(alignment: .leading, spacing: 8) {
-                KeyboardShortcuts.Recorder(for: shortcutName)
-                    .onChange(of: currentShortcut) { _, _ in
-                        ShortcutManager.shared.registerAllShortcuts()
-                    }
+                KeyboardShortcuts.Recorder(for: shortcutName, onChange: handleShortcutChange)
 
                 if shouldShowSuggestions {
                     ShortcutSuggestionRow(
@@ -227,6 +224,16 @@ private struct GroupShortcutEditor: View {
     @MainActor
     private func assignShortcut(_ shortcut: KeyboardShortcuts.Shortcut) {
         KeyboardShortcuts.setShortcut(shortcut, for: shortcutName)
+        refreshShortcutState()
+    }
+
+    @MainActor
+    private func handleShortcutChange(_ shortcut: KeyboardShortcuts.Shortcut?) {
+        refreshShortcutState()
+    }
+
+    @MainActor
+    private func refreshShortcutState() {
         shortcutRefreshToken += 1
         ShortcutManager.shared.registerAllShortcuts()
     }

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -170,6 +170,19 @@ private struct GroupShortcutEditor: View {
         KeyboardShortcuts.getShortcut(for: shortcutName)
     }
 
+    private var cyclingModeSelection: Binding<Bool> {
+        Binding(
+            get: { group.shouldOpenAppIfNeeded },
+            set: { newValue in
+                DispatchQueue.main.async {
+                    var updatedGroup = group
+                    updatedGroup.openAppIfNeeded = newValue
+                    store.updateGroup(updatedGroup)
+                }
+            }
+        )
+    }
+
     private var suggestionShortcuts: [KeyboardShortcuts.Shortcut] {
         ShortcutSuggestions.available(for: store.groups, excluding: groupId)
     }
@@ -185,6 +198,7 @@ private struct GroupShortcutEditor: View {
 
             VStack(alignment: .leading, spacing: 8) {
                 KeyboardShortcuts.Recorder(for: shortcutName, onChange: handleShortcutChange)
+                    .padding(.leading, 4)
 
                 if shouldShowSuggestions {
                     ShortcutSuggestionRow(
@@ -194,22 +208,32 @@ private struct GroupShortcutEditor: View {
                 }
             }
 
-            Picker("Cycling Mode".localized(language: selectedLanguage), selection: Binding(
-                get: { group.shouldOpenAppIfNeeded },
-                set: { newValue in
-                    DispatchQueue.main.async {
-                        var updatedGroup = group
-                        updatedGroup.openAppIfNeeded = newValue
-                        store.updateGroup(updatedGroup)
+            Divider()
+
+            HStack {
+                Text("Cycling Mode".localized(language: selectedLanguage))
+                    .font(.caption.weight(.medium))
+                    .foregroundColor(.secondary)
+
+                ViewThatFits(in: .horizontal) {
+                    Picker("Cycling Mode".localized(language: selectedLanguage), selection: cyclingModeSelection) {
+                        Text("Running apps only".localized(language: selectedLanguage)).tag(false)
+                        Text("All apps (open if needed)".localized(language: selectedLanguage)).tag(true)
                     }
+                    .pickerStyle(.segmented)
+                    .font(.caption)
+                    .labelsHidden()
+                    .fixedSize(horizontal: true, vertical: false)
+
+                    Picker("Cycling Mode".localized(language: selectedLanguage), selection: cyclingModeSelection) {
+                        Text("Running apps only".localized(language: selectedLanguage)).tag(false)
+                        Text("All apps (open if needed)".localized(language: selectedLanguage)).tag(true)
+                    }
+                    .pickerStyle(.menu)
+                    .font(.caption)
+                    .labelsHidden()
                 }
-            )) {
-                Text("Running apps only".localized(language: selectedLanguage)).tag(false)
-                Text("All apps (open if needed)".localized(language: selectedLanguage)).tag(true)
             }
-            .pickerStyle(.segmented)
-            .font(.caption)
-            .padding(.top, 4)
 
             Text(group.shouldOpenAppIfNeeded
                 ? "Cycle through all apps in the group. Non-running apps will be launched when selected.".localized(language: selectedLanguage)

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -9,7 +9,7 @@ import KeyboardShortcuts
 struct GroupEditView: View {
     @EnvironmentObject var store: GroupStore
     let groupId: UUID
-    
+
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     @State private var groupName: String = ""
     @State private var draggingApp: AppItem?
@@ -20,162 +20,264 @@ struct GroupEditView: View {
     private var group: AppGroup? {
         store.groups.first { $0.id == groupId }
     }
-    
+
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                if let group = group {
-                // Group Name
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Group Name".localized(language: selectedLanguage))
-                        .font(.headline)
-                    
-                    TextField("Untitled Group", text: $groupName)
-                        .focused($isNameFocused)
-                        .font(.title2)
-                        .fontWeight(.medium)
-                        .textFieldStyle(.plain)
-                        .padding(.vertical, 4)
-                        .padding(.horizontal, 8)
-                        .background(
-                            RoundedRectangle(cornerRadius: 6)
-                                .fill(isHovering ? Color.secondary.opacity(0.1) : Color.clear)
-                        )
-                        .onHover { hovering in
-                            isHovering = hovering
-                        }
-                        .onChange(of: groupName) { _, newValue in
-                            guard isNameFocused else { return }
-                            var updatedGroup = group
-                            updatedGroup.name = newValue
-                            store.updateGroup(updatedGroup)
-                        }
-                }
-                
-                Divider()
-                
-                // Shortcut
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Keyboard Shortcut".localized(language: selectedLanguage))
-                        .font(.headline)
-                    
-                    HStack {
-                        KeyboardShortcuts.Recorder(for: .forGroup(groupId))
-                        .onChange(of: KeyboardShortcuts.getShortcut(for: .forGroup(groupId))) { _, _ in
-                                // Re-register shortcuts when changed
-                                ShortcutManager.shared.registerAllShortcuts()
-                            }
-                    }
-                    
-                    Picker("Cycling Mode".localized(language: selectedLanguage), selection: Binding(
-                        get: { group.shouldOpenAppIfNeeded },
-                        set: { newValue in
-                            DispatchQueue.main.async {
-                                var updatedGroup = group
-                                updatedGroup.openAppIfNeeded = newValue
-                                store.updateGroup(updatedGroup)
-                            }
-                        }
-                    )) {
-                        Text("Running apps only".localized(language: selectedLanguage)).tag(false)
-                        Text("All apps (open if needed)".localized(language: selectedLanguage)).tag(true)
-                    }
-                    .pickerStyle(.segmented)
-                    .font(.caption)
-                    .padding(.top, 4)
-
-                    Text(group.shouldOpenAppIfNeeded
-                        ? "Cycle through all apps in the group. Non-running apps will be launched when selected.".localized(language: selectedLanguage)
-                        : "Cycle through running apps only. If no app is running, the first app in the group will be launched.".localized(language: selectedLanguage)
-                    )
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding(.top, 2)
-                }
-                
-                Divider()
-                
-                // Apps Grid
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        Text("Applications".localized(language: selectedLanguage))
-                            .font(.headline)
-                        
-                        Spacer()
-                        
-                        Text("\(group.apps.count) \(group.apps.count == 1 ? "app".localized(language: selectedLanguage) : "apps".localized(language: selectedLanguage))")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    
-                    if group.apps.isEmpty {
-                        Text("No apps added yet. Drag apps here or click the drop zone below.".localized(language: selectedLanguage))
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .padding(.vertical, 8)
-                    } else {
-                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 80, maximum: 100))], spacing: 16) {
-                            ForEach(group.apps) { app in
-                                AppGridItemView(app: app) {
-                                    store.removeApp(app, from: groupId)
-                                }
-                                .opacity(draggingApp?.id == app.id ? 0.01 : 1)
-                                .onDrag {
-                                    draggingApp = app
-                                    return NSItemProvider(object: app.id.uuidString as NSString)
-                                }
-                                .onDrop(of: [.text], delegate: AppReorderDelegate(
-                                    item: app,
-                                    draggingApp: $draggingApp,
-                                    store: store,
-                                    groupId: groupId
-                                ))
-                            }
-                        }
-                        .padding(.vertical, 8)
-                        .animation(.default, value: group.apps)
-                    }
-                    
-                    // Drop zone for adding apps
-                    AppDropZoneView(apps: .constant(group.apps)) { app in
-                        store.addApp(app, to: groupId)
-                    }
-                }
-                
-                Spacer()
-            } else {
-                Text("Select a group to edit".localized(language: selectedLanguage))
-                    .foregroundColor(.secondary)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
+            content
         }
         .padding()
-    }
-    .onAppear {
-        loadGroupData()
-        // Prevent the system from auto-focusing the name field on appear
-        suppressAutoFocus = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            suppressAutoFocus = false
+        .onAppear {
+            loadGroupData()
+            // Prevent the system from auto-focusing the name field on appear
+            suppressAutoFocus = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                suppressAutoFocus = false
+            }
+        }
+        .onChange(of: isNameFocused) { _, focused in
+            if focused && suppressAutoFocus {
+                isNameFocused = false
+            }
+        }
+        .onChange(of: groupId) { _, _ in
+            suppressAutoFocus = true
+            loadGroupData()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                suppressAutoFocus = false
+            }
         }
     }
-    .onChange(of: isNameFocused) { _, focused in
-        if focused && suppressAutoFocus {
-            isNameFocused = false
+
+    @ViewBuilder
+    private var content: some View {
+        if let group = group {
+            VStack(alignment: .leading, spacing: 20) {
+                groupNameSection(for: group)
+
+                Divider()
+
+                GroupShortcutEditor(group: group, groupId: groupId)
+
+                Divider()
+
+                appsSection(for: group)
+
+                Spacer()
+            }
+        } else {
+            Text("Select a group to edit".localized(language: selectedLanguage))
+                .foregroundColor(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
-    .onChange(of: groupId) { _, _ in
-        suppressAutoFocus = true
-        loadGroupData()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            suppressAutoFocus = false
+
+    private func groupNameSection(for group: AppGroup) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Group Name".localized(language: selectedLanguage))
+                .font(.headline)
+
+            TextField("Untitled Group", text: $groupName)
+                .focused($isNameFocused)
+                .font(.title2)
+                .fontWeight(.medium)
+                .textFieldStyle(.plain)
+                .padding(.vertical, 4)
+                .padding(.horizontal, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isHovering ? Color.secondary.opacity(0.1) : Color.clear)
+                )
+                .onHover { hovering in
+                    isHovering = hovering
+                }
+                .onChange(of: groupName) { _, newValue in
+                    guard isNameFocused else { return }
+                    var updatedGroup = group
+                    updatedGroup.name = newValue
+                    store.updateGroup(updatedGroup)
+                }
         }
     }
-}
-    
+
+    private func appsSection(for group: AppGroup) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Applications".localized(language: selectedLanguage))
+                    .font(.headline)
+
+                Spacer()
+
+                Text("\(group.apps.count) \(group.apps.count == 1 ? "app".localized(language: selectedLanguage) : "apps".localized(language: selectedLanguage))")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            if group.apps.isEmpty {
+                Text("No apps added yet. Drag apps here or click the drop zone below.".localized(language: selectedLanguage))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.vertical, 8)
+            } else {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 80, maximum: 100))], spacing: 16) {
+                    ForEach(group.apps) { app in
+                        AppGridItemView(app: app) {
+                            store.removeApp(app, from: groupId)
+                        }
+                        .opacity(draggingApp?.id == app.id ? 0.01 : 1)
+                        .onDrag {
+                            draggingApp = app
+                            return NSItemProvider(object: app.id.uuidString as NSString)
+                        }
+                        .onDrop(of: [.text], delegate: AppReorderDelegate(
+                            item: app,
+                            draggingApp: $draggingApp,
+                            store: store,
+                            groupId: groupId
+                        ))
+                    }
+                }
+                .padding(.vertical, 8)
+                .animation(.default, value: group.apps)
+            }
+
+            AppDropZoneView(apps: .constant(group.apps)) { app in
+                store.addApp(app, to: groupId)
+            }
+        }
+    }
+
     private func loadGroupData() {
         if let group = group {
             groupName = group.name
+        }
+    }
+}
+
+private struct GroupShortcutEditor: View {
+    @EnvironmentObject private var store: GroupStore
+
+    let group: AppGroup
+    let groupId: UUID
+
+    @AppStorage("selectedLanguage") private var selectedLanguage = "system"
+    @State private var assignedShortcut: KeyboardShortcuts.Shortcut?
+
+    private var shortcutName: KeyboardShortcuts.Name {
+        .forGroup(groupId)
+    }
+
+    private var currentShortcut: KeyboardShortcuts.Shortcut? {
+        KeyboardShortcuts.getShortcut(for: shortcutName)
+    }
+
+    private var suggestionShortcuts: [KeyboardShortcuts.Shortcut] {
+        ShortcutSuggestions.available(for: store.groups, excluding: groupId)
+    }
+
+    private var shouldShowSuggestions: Bool {
+        assignedShortcut == nil && !suggestionShortcuts.isEmpty
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Keyboard Shortcut".localized(language: selectedLanguage))
+                .font(.headline)
+
+            VStack(alignment: .leading, spacing: 8) {
+                KeyboardShortcuts.Recorder(for: shortcutName)
+                    .onChange(of: currentShortcut) { _, _ in
+                        syncAssignedShortcut()
+                        ShortcutManager.shared.registerAllShortcuts()
+                    }
+
+                if shouldShowSuggestions {
+                    ShortcutSuggestionRow(
+                        suggestions: suggestionShortcuts,
+                        onSelect: assignShortcut
+                    )
+                }
+            }
+
+            Picker("Cycling Mode".localized(language: selectedLanguage), selection: Binding(
+                get: { group.shouldOpenAppIfNeeded },
+                set: { newValue in
+                    DispatchQueue.main.async {
+                        var updatedGroup = group
+                        updatedGroup.openAppIfNeeded = newValue
+                        store.updateGroup(updatedGroup)
+                    }
+                }
+            )) {
+                Text("Running apps only".localized(language: selectedLanguage)).tag(false)
+                Text("All apps (open if needed)".localized(language: selectedLanguage)).tag(true)
+            }
+            .pickerStyle(.segmented)
+            .font(.caption)
+            .padding(.top, 4)
+
+            Text(group.shouldOpenAppIfNeeded
+                ? "Cycle through all apps in the group. Non-running apps will be launched when selected.".localized(language: selectedLanguage)
+                : "Cycle through running apps only. If no app is running, the first app in the group will be launched.".localized(language: selectedLanguage)
+            )
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .padding(.top, 2)
+        }
+        .onAppear {
+            syncAssignedShortcut()
+        }
+        .onChange(of: groupId) { _, _ in
+            syncAssignedShortcut()
+        }
+        .onChange(of: store.groups) { _, _ in
+            syncAssignedShortcut()
+        }
+    }
+
+    @MainActor
+    private func syncAssignedShortcut() {
+        assignedShortcut = currentShortcut
+    }
+
+    @MainActor
+    private func assignShortcut(_ shortcut: KeyboardShortcuts.Shortcut) {
+        KeyboardShortcuts.setShortcut(shortcut, for: shortcutName)
+        assignedShortcut = shortcut
+        ShortcutManager.shared.registerAllShortcuts()
+    }
+}
+
+private struct ShortcutSuggestionRow: View {
+    let suggestions: [KeyboardShortcuts.Shortcut]
+    let onSelect: (KeyboardShortcuts.Shortcut) -> Void
+
+    @AppStorage("selectedLanguage") private var selectedLanguage = "system"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 8) {
+                ForEach(Array(suggestions.enumerated()), id: \.offset) { _, shortcut in
+                    Button {
+                        onSelect(shortcut)
+                    } label: {
+                        Text(shortcut.description)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(
+                                Capsule()
+                                    .fill(Color.secondary.opacity(0.12))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .help(shortcut.description)
+                }
+            }
+
+            Text("Try a simple pattern like ⌥1, ⌥2, and ⌥3.".localized(language: selectedLanguage))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
         }
     }
 }
@@ -193,15 +295,15 @@ struct AppReorderDelegate: DropDelegate {
               let fromIndex = group.apps.firstIndex(of: draggingApp),
               let toIndex = group.apps.firstIndex(of: item)
         else { return }
-        
+
         let destination = toIndex > fromIndex ? toIndex + 1 : toIndex
         store.moveApp(in: groupId, from: IndexSet(integer: fromIndex), to: destination)
     }
-    
+
     func dropUpdated(info: DropInfo) -> DropProposal? {
         return DropProposal(operation: .move)
     }
-    
+
     func performDrop(info: DropInfo) -> Bool {
         draggingApp = nil
         return true
@@ -210,7 +312,7 @@ struct AppReorderDelegate: DropDelegate {
 
 #Preview {
     let store = GroupStore.shared
-    
+
     return GroupEditView(groupId: store.groups.first?.id ?? UUID())
         .environmentObject(store)
         .frame(width: 400, height: 500)

--- a/ShortcutCycle/ShortcutCycleTests/ShortcutSuggestionTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/ShortcutSuggestionTests.swift
@@ -44,8 +44,8 @@ final class ShortcutSuggestionTests: XCTestCase {
 
     @MainActor
     func testAvailableReturnsFewerThanLimitWhenNotEnoughCandidatesRemain() {
-        let optionKeys: [KeyboardShortcuts.Key] = [.one, .two, .three, .four, .five, .six, .seven]
-        let groups = (1...7).map { index in
+        let optionKeys: [KeyboardShortcuts.Key] = [.one, .two, .three, .four, .five, .six, .seven, .eight, .nine]
+        let groups = (1...9).map { index in
             AppGroup(id: UUID(), name: "Group \(index)")
         }
 
@@ -61,8 +61,6 @@ final class ShortcutSuggestionTests: XCTestCase {
 
         let expected: [KeyboardShortcuts.Shortcut] = [
             .init(.one, modifiers: [.option]),
-            .init(.eight, modifiers: [.option]),
-            .init(.nine, modifiers: [.option])
         ]
         let suggestions = ShortcutSuggestions.available(
             for: groups,

--- a/ShortcutCycle/ShortcutCycleTests/ShortcutSuggestionTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/ShortcutSuggestionTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import KeyboardShortcuts
+#if canImport(ShortcutCycleCore)
+@testable import ShortcutCycleCore
+#else
+@testable import ShortcutCycle
+#endif
+
+final class ShortcutSuggestionTests: XCTestCase {
+
+    @MainActor
+    func testAvailableReturnsDeterministicFirstThreeUnusedOptionNumberShortcuts() {
+        let excludedGroup = AppGroup(id: UUID(), name: "Excluded")
+        let assignedGroups = [
+            AppGroup(id: UUID(), name: "First"),
+            AppGroup(id: UUID(), name: "Second"),
+            AppGroup(id: UUID(), name: "Third")
+        ]
+
+        KeyboardShortcuts.setShortcut(.init(.one, modifiers: [.option]), for: excludedGroup.shortcutName)
+        KeyboardShortcuts.setShortcut(.init(.two, modifiers: [.option]), for: assignedGroups[0].shortcutName)
+        KeyboardShortcuts.setShortcut(.init(.three, modifiers: [.option]), for: assignedGroups[1].shortcutName)
+        KeyboardShortcuts.setShortcut(.init(.four, modifiers: [.option]), for: assignedGroups[2].shortcutName)
+
+        defer {
+            KeyboardShortcuts.setShortcut(nil, for: excludedGroup.shortcutName)
+            assignedGroups.forEach { group in
+                KeyboardShortcuts.setShortcut(nil, for: group.shortcutName)
+            }
+        }
+
+        let expected: [KeyboardShortcuts.Shortcut] = [
+            .init(.one, modifiers: [.option]),
+            .init(.five, modifiers: [.option]),
+            .init(.six, modifiers: [.option])
+        ]
+        let suggestions = ShortcutSuggestions.available(
+            for: [excludedGroup] + assignedGroups,
+            excluding: excludedGroup.id
+        )
+
+        XCTAssertEqual(suggestions, expected)
+    }
+
+    @MainActor
+    func testAvailableReturnsFewerThanLimitWhenNotEnoughCandidatesRemain() {
+        let optionKeys: [KeyboardShortcuts.Key] = [.one, .two, .three, .four, .five, .six, .seven]
+        let groups = (1...7).map { index in
+            AppGroup(id: UUID(), name: "Group \(index)")
+        }
+
+        for (index, group) in groups.enumerated() {
+            KeyboardShortcuts.setShortcut(.init(optionKeys[index], modifiers: [.option]), for: group.shortcutName)
+        }
+
+        defer {
+            groups.forEach { group in
+                KeyboardShortcuts.setShortcut(nil, for: group.shortcutName)
+            }
+        }
+
+        let expected: [KeyboardShortcuts.Shortcut] = [
+            .init(.one, modifiers: [.option]),
+            .init(.eight, modifiers: [.option]),
+            .init(.nine, modifiers: [.option])
+        ]
+        let suggestions = ShortcutSuggestions.available(
+            for: groups,
+            excluding: groups[0].id
+        )
+
+        XCTAssertEqual(suggestions, expected)
+    }
+}

--- a/docs/superpowers/specs/2026-04-01-shortcut-suggestions-design.md
+++ b/docs/superpowers/specs/2026-04-01-shortcut-suggestions-design.md
@@ -1,0 +1,89 @@
+# Shortcut Suggestions For Unassigned Groups
+
+## Summary
+
+Add lightweight shortcut suggestion chips to the group editor when a group does not yet have an assigned keyboard shortcut. The goal is to reduce first-run decision friction without introducing a separate onboarding flow.
+
+## Current Context
+
+The shortcut assignment flow already lives in `GroupEditView`. Users can record a shortcut there, but the UI does not currently suggest what kinds of shortcuts work well. Issue `#38` asks for simple guidance that helps users pick a shortcut pattern quickly.
+
+## Goals
+
+- Help first-time users choose a shortcut pattern faster
+- Keep the guidance local to the existing group edit flow
+- Make suggestions actionable instead of purely instructional
+- Avoid conflicts with shortcuts already assigned to other groups
+
+## Non-Goals
+
+- No onboarding modal, wizard, or banner flow
+- No complex recommendation engine based on group name or app contents
+- No fallback to unusual shortcut combinations if common ones are unavailable
+
+## Recommended Approach
+
+Show a small row of click-to-apply suggestion chips directly under the existing keyboard shortcut recorder in `GroupEditView`.
+
+### Behavior
+
+- Only show the suggestion row when the current group has no assigned shortcut
+- Render up to 3 suggestion chips
+- Clicking a chip immediately assigns that shortcut to the current group
+- Hide the suggestion row immediately after any shortcut is assigned, whether via chip or recorder
+- Show one brief helper line under the chips explaining the pattern, for example that many people use one modifier plus numbers for each group
+
+### Suggestion Generation
+
+Use a deterministic ordered candidate list instead of a dynamic heuristic.
+
+Primary candidate order:
+
+- `Option + 1`
+- `Option + 2`
+- `Option + 3`
+- ...
+- `Option + 9`
+
+Selection rules:
+
+- Exclude any shortcut already assigned to a different group
+- Take the first available candidates until 3 suggestions are collected
+- If fewer than 3 are available, show fewer
+- If none are available, show no suggestion chips
+
+This keeps the UI predictable, easy to explain, and aligned with the product's existing examples.
+
+## Interaction Notes
+
+- Suggestion chips should feel secondary to the recorder, not like the main control
+- The UI should not display suggestions that cannot be applied successfully
+- Immediate assignment is preferred over inserting a hint into the recorder, because the feature is meant to reduce friction rather than add another step
+
+## Data And Logic Placement
+
+- UI rendering belongs in `GroupEditView`
+- Suggestion generation should be implemented as a small, testable unit rather than embedded inline in the view body
+- Conflict detection should reuse the same underlying shortcut source of truth already used by the recorder and shortcut manager
+
+## Edge Cases
+
+- Groups with an existing shortcut never show the suggestion row
+- If the user clears a shortcut, the suggestion row can reappear
+- If all preferred suggestions are unavailable, the recorder remains the only path
+- If the current group somehow already holds one of the preferred shortcuts, the row stays hidden because the group is no longer unassigned
+
+## Validation
+
+The implementation should verify:
+
+- suggestion chips appear only for groups without shortcuts
+- only unused suggestions are shown
+- clicking a suggestion assigns the shortcut and refreshes shortcut registration
+- the suggestion row disappears after assignment
+
+## Open Decisions Resolved
+
+- Use suggestion chips rather than passive text or a broader onboarding UI
+- Chips are click-to-apply, not examples only
+- Suggestions are deterministic from a short preferred list, not personalized


### PR DESCRIPTION
## Summary
- Add a deterministic shortcut suggestion helper for unused `Option + 1...9` combinations, plus focused tests
- Show click-to-apply suggestion chips under the existing group shortcut recorder and refresh registrations on recorder/chip changes
- Localize the new helper guidance across all 15 supported languages
- Restore `ViewThatFits` cycling mode picker layout (segmented → menu fallback on narrow windows)
- Add visual separator (Divider) between keyboard shortcut and cycling mode sub-sections
- Fix shortcut recorder focus ring clipping at the left edge of the scroll view

## Why
Creating a group currently presents a shortcut recorder with no guidance, which adds decision friction for first-time users. The cycling mode picker also lost its adaptive narrow-window layout during a merge conflict resolution.

## Test Plan
- [x] `cd ShortcutCycle && swift test`
- [x] `cd ShortcutCycle && swift test --filter ShortcutSuggestionTests`
- [x] `cd ShortcutCycle && swift test --filter LocalizationTests`
- [x] Manual UI smoke test: verify suggestion chips appear for groups with no shortcut
- [x] Manual UI smoke test: verify cycling mode picker falls back to menu style on narrow window
- [x] Manual UI smoke test: verify recorder focus ring is not clipped