### PR TITLE
Add running-app quick add to the group editor

### DIFF
--- a/ShortcutCycle/ShortcutCycle/Models/AppItem.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/AppItem.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 /// Represents a single application that can be part of a group
@@ -29,5 +30,65 @@ public struct AppItem: Identifiable, Codable, Equatable, Hashable {
             name: name,
             iconPath: appURL.path
         )
+    }
+}
+
+public struct RunningAppQuickAddSource: Equatable {
+    public let bundleIdentifier: String
+    public let bundleURL: URL?
+    public let activationPolicy: NSApplication.ActivationPolicy
+
+    public init(
+        bundleIdentifier: String,
+        bundleURL: URL?,
+        activationPolicy: NSApplication.ActivationPolicy = .regular
+    ) {
+        self.bundleIdentifier = bundleIdentifier
+        self.bundleURL = bundleURL
+        self.activationPolicy = activationPolicy
+    }
+
+    public init?(runningApplication: NSRunningApplication) {
+        guard let bundleIdentifier = runningApplication.bundleIdentifier else {
+            return nil
+        }
+
+        self.init(
+            bundleIdentifier: bundleIdentifier,
+            bundleURL: runningApplication.bundleURL
+                ?? NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier),
+            activationPolicy: runningApplication.activationPolicy
+        )
+    }
+}
+
+public enum RunningAppQuickAdd {
+    public static func candidates(
+        for groupApps: [AppItem],
+        runningApps: [RunningAppQuickAddSource],
+        excludedBundleIdentifiers: Set<String> = []
+    ) -> [AppItem] {
+        let existingBundleIdentifiers = Set(groupApps.map(\.bundleIdentifier))
+        let excluded = existingBundleIdentifiers.union(excludedBundleIdentifiers)
+        var seenBundleIdentifiers = Set<String>()
+
+        let candidates = runningApps.compactMap { runningApp -> AppItem? in
+            guard runningApp.activationPolicy == .regular else { return nil }
+            guard !excluded.contains(runningApp.bundleIdentifier) else { return nil }
+            guard seenBundleIdentifiers.insert(runningApp.bundleIdentifier).inserted else { return nil }
+            guard let appURL = runningApp.bundleURL else { return nil }
+            return AppItem.from(appURL: appURL)
+        }
+
+        return candidates.sorted { lhs, rhs in
+            let lhsKey = lhs.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            let rhsKey = rhs.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+
+            if lhsKey == rhsKey {
+                return lhs.bundleIdentifier < rhs.bundleIdentifier
+            }
+
+            return lhsKey < rhsKey
+        }
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Models/AppItem.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/AppItem.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 
 /// Represents a single application that can be part of a group
@@ -36,29 +35,16 @@ public struct AppItem: Identifiable, Codable, Equatable, Hashable {
 public struct RunningAppQuickAddSource: Equatable {
     public let bundleIdentifier: String
     public let bundleURL: URL?
-    public let activationPolicy: NSApplication.ActivationPolicy
+    public let isRegularApp: Bool
 
     public init(
         bundleIdentifier: String,
         bundleURL: URL?,
-        activationPolicy: NSApplication.ActivationPolicy = .regular
+        isRegularApp: Bool = true
     ) {
         self.bundleIdentifier = bundleIdentifier
         self.bundleURL = bundleURL
-        self.activationPolicy = activationPolicy
-    }
-
-    public init?(runningApplication: NSRunningApplication) {
-        guard let bundleIdentifier = runningApplication.bundleIdentifier else {
-            return nil
-        }
-
-        self.init(
-            bundleIdentifier: bundleIdentifier,
-            bundleURL: runningApplication.bundleURL
-                ?? NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier),
-            activationPolicy: runningApplication.activationPolicy
-        )
+        self.isRegularApp = isRegularApp
     }
 }
 
@@ -73,7 +59,7 @@ public enum RunningAppQuickAdd {
         var seenBundleIdentifiers = Set<String>()
 
         let candidates = runningApps.compactMap { runningApp -> AppItem? in
-            guard runningApp.activationPolicy == .regular else { return nil }
+            guard runningApp.isRegularApp else { return nil }
             guard !excluded.contains(runningApp.bundleIdentifier) else { return nil }
             guard seenBundleIdentifiers.insert(runningApp.bundleIdentifier).inserted else { return nil }
             guard let appURL = runningApp.bundleURL else { return nil }

--- a/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "أدخل اسم المجموعة";
 "Keyboard Shortcut" = "اختصار لوحة المفاتيح";
 "Applications" = "التطبيقات";
+"Add Apps" = "إضافة تطبيقات";
+"Browse or drag from Finder" = "تصفح أو اسحب من Finder";
+"Click to add currently open apps to this group." = "انقر لإضافة التطبيقات المفتوحة حالياً إلى هذه المجموعة.";
+"No apps in this group yet." = "لا توجد تطبيقات في هذه المجموعة بعد.";
+"Running Apps" = "التطبيقات قيد التشغيل";
 "app" = "تطبيق";
 "apps" = "تطبيقات";
 "No apps added yet. Drag apps here or click the drop zone below." = "لم يتم إضافة تطبيقات بعد. اسحب التطبيقات هنا أو انقر فوق المنطقة أدناه.";

--- a/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "Gruppenname eingeben";
 "Keyboard Shortcut" = "Tastenkürzel";
 "Applications" = "Anwendungen";
+"Add Apps" = "Apps hinzufügen";
+"Browse or drag from Finder" = "Im Finder auswählen oder hineinziehen";
+"Click to add currently open apps to this group." = "Klicken Sie, um aktuell geöffnete Apps zu dieser Gruppe hinzuzufügen.";
+"No apps in this group yet." = "Noch keine Apps in dieser Gruppe.";
+"Running Apps" = "Laufende Apps";
 "app" = "App";
 "apps" = "Apps";
 "No apps added yet. Drag apps here or click the drop zone below." = "Noch keine Apps hinzugefügt. Ziehen Sie Apps hierher oder klicken Sie auf den Ablagebereich unten.";

--- a/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "Enter group name";
 "Keyboard Shortcut" = "Keyboard Shortcut";
 "Applications" = "Applications";
+"Add Apps" = "Add Apps";
+"Browse or drag from Finder" = "Browse or drag from Finder";
+"Click to add currently open apps to this group." = "Click to add currently open apps to this group.";
+"No apps in this group yet." = "No apps in this group yet.";
+"Running Apps" = "Running Apps";
 "app" = "app";
 "apps" = "apps";
 "No apps added yet. Drag apps here or click the drop zone below." = "No apps added yet. Drag apps here or click the drop zone below.";

--- a/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "Introduce el nombre del grupo";
 "Keyboard Shortcut" = "Atajo de teclado";
 "Applications" = "Aplicaciones";
+"Add Apps" = "Agregar aplicaciones";
+"Browse or drag from Finder" = "Buscar o arrastrar desde Finder";
+"Click to add currently open apps to this group." = "Haz clic para agregar las aplicaciones abiertas actualmente a este grupo.";
+"No apps in this group yet." = "Todavía no hay aplicaciones en este grupo.";
+"Running Apps" = "Aplicaciones en ejecución";
 "app" = "app";
 "apps" = "apps";
 "No apps added yet. Drag apps here or click the drop zone below." = "No hay aplicaciones añadidas. Arrastra aplicaciones aquí o haz clic en la zona inferior.";

--- a/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "Entrer le nom du groupe";
 "Keyboard Shortcut" = "Raccourci clavier";
 "Applications" = "Applications";
+"Add Apps" = "Ajouter des apps";
+"Browse or drag from Finder" = "Parcourir ou glisser depuis le Finder";
+"Click to add currently open apps to this group." = "Cliquez pour ajouter les applications actuellement ouvertes à ce groupe.";
+"No apps in this group yet." = "Aucune application dans ce groupe pour le moment.";
+"Running Apps" = "Applications en cours";
 "app" = "app";
 "apps" = "apps";
 "No apps added yet. Drag apps here or click the drop zone below." = "Aucune application ajoutée. Faites glisser des applications ici ou cliquez sur la zone ci-dessous.";

--- a/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "Inserisci nome gruppo";
 "Keyboard Shortcut" = "Scorciatoia da tastiera";
 "Applications" = "Applicazioni";
+"Add Apps" = "Aggiungi app";
+"Browse or drag from Finder" = "Sfoglia o trascina dal Finder";
+"Click to add currently open apps to this group." = "Fai clic per aggiungere a questo gruppo le app attualmente aperte.";
+"No apps in this group yet." = "Nessuna app in questo gruppo per ora.";
+"Running Apps" = "App in esecuzione";
 "app" = "app";
 "apps" = "app";
 "No apps added yet. Drag apps here or click the drop zone below." = "Nessuna app aggiunta. Trascina le app qui o clicca l'area sottostante.";

--- a/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "グループ名を入力";
 "Keyboard Shortcut" = "キーボードショートカット";
 "Applications" = "アプリケーション";
+"Add Apps" = "アプリを追加";
+"Browse or drag from Finder" = "Finder から選択またはドラッグ";
+"Click to add currently open apps to this group." = "クリックして現在開いているアプリをこのグループに追加します。";
+"No apps in this group yet." = "このグループにはまだアプリがありません。";
+"Running Apps" = "実行中のアプリ";
 "app" = "アプリ";
 "apps" = "アプリ";
 "No apps added yet. Drag apps here or click the drop zone below." = "アプリはまだ追加されていません。ここにアプリをドラッグするか、下のドロップゾーンをクリックしてください。";

--- a/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "그룹 이름 입력";
 "Keyboard Shortcut" = "키보드 단축키";
 "Applications" = "애플리케이션";
+"Add Apps" = "앱 추가";
+"Browse or drag from Finder" = "Finder에서 찾아보거나 드래그";
+"Click to add currently open apps to this group." = "클릭하여 현재 열려 있는 앱을 이 그룹에 추가하세요.";
+"No apps in this group yet." = "이 그룹에는 아직 앱이 없습니다.";
+"Running Apps" = "실행 중인 앱";
 "app" = "개 앱";
 "apps" = "개 앱";
 "No apps added yet. Drag apps here or click the drop zone below." = "앱이 추가되지 않았습니다. 여기로 앱을 드래그하거나 아래 영역을 클릭하세요.";

--- a/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "Voer groepsnaam in";
 "Keyboard Shortcut" = "Sneltoets";
 "Applications" = "Applicaties";
+"Add Apps" = "Apps toevoegen";
+"Browse or drag from Finder" = "Bladeren of slepen vanuit Finder";
+"Click to add currently open apps to this group." = "Klik om momenteel geopende apps aan deze groep toe te voegen.";
+"No apps in this group yet." = "Er zitten nog geen apps in deze groep.";
+"Running Apps" = "Actieve apps";
 "app" = "app";
 "apps" = "apps";
 "No apps added yet. Drag apps here or click the drop zone below." = "Nog geen apps toegevoegd. Sleep apps hierheen of klik op het gebied hieronder.";

--- a/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "Wprowadź nazwę grupy";
 "Keyboard Shortcut" = "Skrót klawiszowy";
 "Applications" = "Aplikacje";
+"Add Apps" = "Dodaj aplikacje";
+"Browse or drag from Finder" = "Przeglądaj lub przeciągnij z Findera";
+"Click to add currently open apps to this group." = "Kliknij, aby dodać obecnie otwarte aplikacje do tej grupy.";
+"No apps in this group yet." = "W tej grupie nie ma jeszcze aplikacji.";
+"Running Apps" = "Uruchomione aplikacje";
 "app" = "aplikacja";
 "apps" = "aplikacje";
 "No apps added yet. Drag apps here or click the drop zone below." = "Brak dodanych aplikacji. Przeciągnij aplikacje tutaj lub kliknij obszar poniżej.";

--- a/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "Digite o nome do grupo";
 "Keyboard Shortcut" = "Atalho de Teclado";
 "Applications" = "Aplicativos";
+"Add Apps" = "Adicionar apps";
+"Browse or drag from Finder" = "Procurar ou arrastar do Finder";
+"Click to add currently open apps to this group." = "Clique para adicionar os apps abertos no momento a este grupo.";
+"No apps in this group yet." = "Ainda não há apps neste grupo.";
+"Running Apps" = "Apps em execução";
 "app" = "app";
 "apps" = "apps";
 "No apps added yet. Drag apps here or click the drop zone below." = "Nenhum app adicionado. Arraste apps para cá ou clique na área abaixo.";

--- a/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "Введите имя группы";
 "Keyboard Shortcut" = "Сочетание клавиш";
 "Applications" = "Приложения";
+"Add Apps" = "Добавить приложения";
+"Browse or drag from Finder" = "Выбрать или перетащить из Finder";
+"Click to add currently open apps to this group." = "Нажмите, чтобы добавить в эту группу открытые сейчас приложения.";
+"No apps in this group yet." = "В этой группе пока нет приложений.";
+"Running Apps" = "Запущенные приложения";
 "app" = "приложение";
 "apps" = "приложения";
 "No apps added yet. Drag apps here or click the drop zone below." = "Приложения еще не добавлены. Перетащите приложения сюда или нажмите на область ниже.";

--- a/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "Grup adı girin";
 "Keyboard Shortcut" = "Klavye Kısayolu";
 "Applications" = "Uygulamalar";
+"Add Apps" = "Uygulama ekle";
+"Browse or drag from Finder" = "Finder'dan göz at veya sürükle";
+"Click to add currently open apps to this group." = "Şu anda açık olan uygulamaları bu gruba eklemek için tıklayın.";
+"No apps in this group yet." = "Bu grupta henüz uygulama yok.";
+"Running Apps" = "Çalışan uygulamalar";
 "app" = "uygulama";
 "apps" = "uygulamalar";
 "No apps added yet. Drag apps here or click the drop zone below." = "Henüz uygulama eklenmedi. Uygulamaları buraya sürükleyin veya aşağıdaki alana tıklayın.";

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "输入群组名称";
 "Keyboard Shortcut" = "键盘快捷键";
 "Applications" = "应用程序";
+"Add Apps" = "添加应用";
+"Browse or drag from Finder" = "从 Finder 浏览或拖入";
+"Click to add currently open apps to this group." = "点击以将当前打开的应用添加到此群组。";
+"No apps in this group yet." = "此群组中还没有应用。";
+"Running Apps" = "正在运行的应用";
 "app" = "个应用";
 "apps" = "个应用";
 "No apps added yet. Drag apps here or click the drop zone below." = "尚未添加应用。将应用拖到此处或点击下方的放置区域。";

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
@@ -18,6 +18,11 @@
 "Enter group name" = "輸入群組名稱";
 "Keyboard Shortcut" = "鍵盤快速鍵";
 "Applications" = "應用程式";
+"Add Apps" = "加入應用程式";
+"Browse or drag from Finder" = "從 Finder 瀏覽或拖曳";
+"Click to add currently open apps to this group." = "按一下以將目前開啟的應用程式加入此群組。";
+"No apps in this group yet." = "此群組中還沒有應用程式。";
+"Running Apps" = "正在執行的應用程式";
 "app" = "個應用";
 "apps" = "個應用";
 "No apps added yet. Drag apps here or click the drop zone below." = "尚未加入應用程式。將應用程式拖到此處或按一下下方的放置區域。";

--- a/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
@@ -67,19 +67,19 @@ struct AppGridItemView: View {
     @State private var isHovered = false
     
     var body: some View {
-        VStack(spacing: 6) {
+        VStack(spacing: 8) {
             ZStack(alignment: .topTrailing) {
                 // App icon
                 Group {
                     if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: app.bundleIdentifier) {
                         Image(nsImage: NSWorkspace.shared.icon(forFile: appURL.path))
                             .resizable()
-                            .frame(width: 48, height: 48)
+                            .frame(width: 56, height: 56)
                     } else {
                         Image(systemName: "app.fill")
-                            .font(.system(size: 36))
+                            .font(.system(size: 42))
                             .foregroundColor(.secondary)
-                            .frame(width: 48, height: 48)
+                            .frame(width: 56, height: 56)
                     }
                 }
                 
@@ -100,9 +100,9 @@ struct AppGridItemView: View {
                 .font(.caption)
                 .lineLimit(2)
                 .multilineTextAlignment(.center)
-                .frame(width: 80)
+                .frame(width: 88)
         }
-        .padding(8)
+        .padding(10)
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .fill(isHovered ? Color.accentColor.opacity(0.1) : Color.clear)
@@ -122,9 +122,9 @@ struct AppDropZoneView: View {
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: 10) {
             Image(systemName: "plus.app")
-                .font(.system(size: 24))
+                .font(.system(size: 28))
                 .foregroundColor(isTargeted ? .accentColor : .secondary)
             
             Text("Drop or click to add apps".localized(language: selectedLanguage))
@@ -132,7 +132,7 @@ struct AppDropZoneView: View {
                 .foregroundColor(isTargeted ? .accentColor : .secondary)
         }
         .frame(maxWidth: .infinity)
-        .frame(height: 80)
+        .frame(height: 112)
         .background(
             RoundedRectangle(cornerRadius: 12)
                 .strokeBorder(

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 #if canImport(ShortcutCycleCore)
 import ShortcutCycleCore
 #endif
+import AppKit
 import UniformTypeIdentifiers
 import KeyboardShortcuts
 
@@ -9,6 +10,7 @@ import KeyboardShortcuts
 struct GroupEditView: View {
     @EnvironmentObject var store: GroupStore
     let groupId: UUID
+    private let runningAppCandidatesProvider: ([AppItem]) -> [AppItem]
 
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     @State private var groupName: String = ""
@@ -16,6 +18,15 @@ struct GroupEditView: View {
     @State private var isHovering: Bool = false
     @FocusState private var isNameFocused: Bool
     @State private var suppressAutoFocus = true
+    @State private var runningAppsRefreshToken = 0
+
+    init(
+        groupId: UUID,
+        runningAppCandidatesProvider: @escaping ([AppItem]) -> [AppItem] = GroupEditView.defaultRunningAppCandidates(for:)
+    ) {
+        self.groupId = groupId
+        self.runningAppCandidatesProvider = runningAppCandidatesProvider
+    }
 
     private var group: AppGroup? {
         store.groups.first { $0.id == groupId }
@@ -45,6 +56,12 @@ struct GroupEditView: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 suppressAutoFocus = false
             }
+        }
+        .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didLaunchApplicationNotification)) { _ in
+            runningAppsRefreshToken += 1
+        }
+        .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didTerminateApplicationNotification)) { _ in
+            runningAppsRefreshToken += 1
         }
     }
 
@@ -100,7 +117,9 @@ struct GroupEditView: View {
     }
 
     private func appsSection(for group: AppGroup) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+        let quickAddCandidates = runningAppCandidates(for: group)
+
+        return VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Text("Applications".localized(language: selectedLanguage))
                     .font(.headline)
@@ -113,10 +132,12 @@ struct GroupEditView: View {
             }
 
             if group.apps.isEmpty {
-                Text("No apps added yet. Drag apps here or click the drop zone below.".localized(language: selectedLanguage))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding(.vertical, 8)
+                if Self.shouldShowEmptyAppsState(groupApps: group.apps) {
+                    Text("No apps in this group yet.".localized(language: selectedLanguage))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.vertical, 8)
+                }
             } else {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 80, maximum: 100))], spacing: 16) {
                     ForEach(group.apps) { app in
@@ -140,6 +161,76 @@ struct GroupEditView: View {
                 .animation(.default, value: group.apps)
             }
 
+            addAppsPanel(for: group, quickAddCandidates: quickAddCandidates)
+        }
+    }
+
+    private func addAppsPanel(for group: AppGroup, quickAddCandidates: [AppItem]) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Add Apps".localized(language: selectedLanguage))
+                .font(.caption.weight(.semibold))
+                .foregroundColor(.secondary)
+
+            if Self.shouldShowRunningAppQuickAddSection(quickAddCandidates) {
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .top, spacing: 12) {
+                        runningAppsOptionCard(quickAddCandidates)
+                            .frame(minWidth: 360, maxWidth: .infinity, alignment: .leading)
+
+                        Divider()
+                            .padding(.vertical, 4)
+
+                        browseAppsOptionCard(for: group)
+                            .frame(minWidth: 220, idealWidth: 240, maxWidth: 280, alignment: .leading)
+                    }
+
+                    VStack(alignment: .leading, spacing: 12) {
+                        runningAppsOptionCard(quickAddCandidates)
+                        browseAppsOptionCard(for: group)
+                    }
+                }
+            } else {
+                browseAppsOptionCard(for: group)
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.75))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(Color.secondary.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    private func runningAppsOptionCard(_ quickAddCandidates: [AppItem]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Running Apps".localized(language: selectedLanguage))
+                .font(.caption.weight(.medium))
+                .foregroundColor(.secondary)
+
+            Text("Click to add currently open apps to this group.".localized(language: selectedLanguage))
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 78, maximum: 90))], spacing: 10) {
+                ForEach(quickAddCandidates) { app in
+                    RunningAppQuickAddButton(app: app) {
+                        store.addApp(app, to: groupId)
+                    }
+                }
+            }
+        }
+    }
+
+    private func browseAppsOptionCard(for group: AppGroup) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Browse or drag from Finder".localized(language: selectedLanguage))
+                .font(.caption.weight(.medium))
+                .foregroundColor(.secondary)
+
             AppDropZoneView(apps: .constant(group.apps)) { app in
                 store.addApp(app, to: groupId)
             }
@@ -150,6 +241,88 @@ struct GroupEditView: View {
         if let group = group {
             groupName = group.name
         }
+    }
+
+    private func runningAppCandidates(for group: AppGroup) -> [AppItem] {
+        _ = runningAppsRefreshToken
+        return runningAppCandidatesProvider(group.apps)
+    }
+
+    private static func defaultRunningAppCandidates(for groupApps: [AppItem]) -> [AppItem] {
+        let runningApps = NSWorkspace.shared.runningApplications.compactMap(RunningAppQuickAddSource.init(runningApplication:))
+        let excludedBundleIdentifiers = Set(["com.xcv58.ShortcutCycle", Bundle.main.bundleIdentifier].compactMap { $0 })
+        return RunningAppQuickAdd.candidates(
+            for: groupApps,
+            runningApps: runningApps,
+            excludedBundleIdentifiers: excludedBundleIdentifiers
+        )
+    }
+
+    static func shouldShowRunningAppQuickAddSection(_ quickAddCandidates: [AppItem]) -> Bool {
+        !quickAddCandidates.isEmpty
+    }
+
+    static func shouldShowEmptyAppsState(groupApps: [AppItem]) -> Bool {
+        groupApps.isEmpty
+    }
+}
+
+private struct RunningAppQuickAddButton: View {
+    let app: AppItem
+    let onAdd: () -> Void
+
+    @AppStorage("selectedLanguage") private var selectedLanguage = "system"
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: onAdd) {
+            VStack(spacing: 6) {
+                ZStack(alignment: .topTrailing) {
+                    Group {
+                        if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: app.bundleIdentifier) {
+                            Image(nsImage: NSWorkspace.shared.icon(forFile: appURL.path))
+                                .resizable()
+                                .frame(width: 30, height: 30)
+                        } else {
+                            Image(systemName: "app.fill")
+                                .font(.system(size: 24))
+                                .foregroundColor(.secondary)
+                                .frame(width: 30, height: 30)
+                        }
+                    }
+
+                    Image(systemName: "plus.circle.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                        .symbolRenderingMode(.palette)
+                        .foregroundStyle(.white, Color.accentColor)
+                        .background(Color(nsColor: .controlBackgroundColor), in: Circle())
+                        .offset(x: 4, y: -4)
+                }
+
+                Text(app.name)
+                    .font(.caption2)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .frame(width: 64)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 6)
+            .padding(.horizontal, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(isHovered ? Color.accentColor.opacity(0.10) : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(isHovered ? Color.accentColor.opacity(0.28) : Color.clear, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            isHovered = hovering
+        }
+        .accessibilityLabel("\("Add".localized(language: selectedLanguage)) \(app.name)")
+        .help(app.name)
     }
 }
 

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -132,12 +132,10 @@ struct GroupEditView: View {
             }
 
             if group.apps.isEmpty {
-                if Self.shouldShowEmptyAppsState(groupApps: group.apps) {
-                    Text("No apps in this group yet.".localized(language: selectedLanguage))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .padding(.vertical, 8)
-                }
+                Text("No apps in this group yet.".localized(language: selectedLanguage))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.vertical, 8)
             } else {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 80, maximum: 100))], spacing: 16) {
                     ForEach(group.apps) { app in
@@ -249,7 +247,14 @@ struct GroupEditView: View {
     }
 
     private static func defaultRunningAppCandidates(for groupApps: [AppItem]) -> [AppItem] {
-        let runningApps = NSWorkspace.shared.runningApplications.compactMap(RunningAppQuickAddSource.init(runningApplication:))
+        let runningApps: [RunningAppQuickAddSource] = NSWorkspace.shared.runningApplications.compactMap { app in
+            guard let bundleIdentifier = app.bundleIdentifier else { return nil }
+            return RunningAppQuickAddSource(
+                bundleIdentifier: bundleIdentifier,
+                bundleURL: app.bundleURL ?? NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier),
+                isRegularApp: app.activationPolicy == .regular
+            )
+        }
         let excludedBundleIdentifiers = Set(["com.xcv58.ShortcutCycle", Bundle.main.bundleIdentifier].compactMap { $0 })
         return RunningAppQuickAdd.candidates(
             for: groupApps,
@@ -260,10 +265,6 @@ struct GroupEditView: View {
 
     static func shouldShowRunningAppQuickAddSection(_ quickAddCandidates: [AppItem]) -> Bool {
         !quickAddCandidates.isEmpty
-    }
-
-    static func shouldShowEmptyAppsState(groupApps: [AppItem]) -> Bool {
-        groupApps.isEmpty
     }
 }
 

--- a/ShortcutCycle/ShortcutCycle/Views/MainView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/MainView.swift
@@ -30,7 +30,7 @@ struct MainView: View {
             TabView(selection: $selectedTab) {
                 GroupSettingsView()
                     .tabItem {
-                        Label("Groups".localized(language: selectedLanguage), systemImage: "rectangle.stack.3.hexagon")
+                        Label("Groups".localized(language: selectedLanguage), systemImage: "square.grid.2x2")
                     }
                     .tag(URLSettingsTab.groups.rawValue)
 
@@ -73,7 +73,7 @@ struct MainView: View {
             Text("This action cannot be undone.".localized(language: selectedLanguage))
         }
         .preferredColorScheme(appTheme.colorScheme)
-        .frame(minWidth: 600, minHeight: 400)
+        .frame(minWidth: 880, minHeight: 540)
         .environment(\.locale, LanguageManager.shared.locale)
         .id("\(selectedLanguage)-\(localeObserver.id)") // Force full redraw when language or system locale changes
     }

--- a/ShortcutCycle/ShortcutCycle/Views/MainView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/MainView.swift
@@ -73,7 +73,7 @@ struct MainView: View {
             Text("This action cannot be undone.".localized(language: selectedLanguage))
         }
         .preferredColorScheme(appTheme.colorScheme)
-        .frame(minWidth: 880, minHeight: 540)
+        .frame(minWidth: 720, minHeight: 460)
         .environment(\.locale, LanguageManager.shared.locale)
         .id("\(selectedLanguage)-\(localeObserver.id)") // Force full redraw when language or system locale changes
     }

--- a/ShortcutCycle/ShortcutCycleTests/AppItemTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/AppItemTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 #if canImport(ShortcutCycleCore)
 @testable import ShortcutCycleCore
@@ -163,5 +164,82 @@ final class AppItemTests: XCTestCase {
         let item = AppItem.from(appURL: appDir)
 
         XCTAssertNil(item)
+    }
+
+    // MARK: - RunningAppQuickAdd
+
+    func testRunningAppQuickAddFiltersSelfExistingAppsAndNonRegularApps() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let finderURL = try makeAppBundle(name: "Finder", bundleIdentifier: "com.apple.finder", in: tempDir)
+        let mailURL = try makeAppBundle(name: "Mail", bundleIdentifier: "com.test.mail", in: tempDir)
+        let browserURL = try makeAppBundle(name: "Browser", bundleIdentifier: "com.test.browser", in: tempDir)
+        let helperURL = try makeAppBundle(name: "Helper", bundleIdentifier: "com.test.helper", in: tempDir)
+        let shortcutCycleURL = try makeAppBundle(name: "ShortcutCycle", bundleIdentifier: "com.xcv58.ShortcutCycle", in: tempDir)
+
+        let groupApps = [AppItem(bundleIdentifier: "com.test.browser", name: "Browser")]
+        let candidates = RunningAppQuickAdd.candidates(
+            for: groupApps,
+            runningApps: [
+                RunningAppQuickAddSource(bundleIdentifier: "com.xcv58.ShortcutCycle", bundleURL: shortcutCycleURL),
+                RunningAppQuickAddSource(bundleIdentifier: "com.apple.finder", bundleURL: finderURL),
+                RunningAppQuickAddSource(bundleIdentifier: "com.test.mail", bundleURL: mailURL),
+                RunningAppQuickAddSource(bundleIdentifier: "com.test.helper", bundleURL: helperURL, activationPolicy: .accessory),
+                RunningAppQuickAddSource(bundleIdentifier: "com.test.browser", bundleURL: browserURL)
+            ],
+            excludedBundleIdentifiers: ["com.xcv58.ShortcutCycle"]
+        )
+
+        XCTAssertEqual(candidates.map(\.bundleIdentifier), ["com.apple.finder", "com.test.mail"])
+        XCTAssertEqual(candidates.map(\.name), ["Finder", "Mail"])
+    }
+
+    func testRunningAppQuickAddDedupesBundleIdentifiersAndSortsAlphabetically() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let zebraURL = try makeAppBundle(name: "zebra", bundleIdentifier: "com.test.zebra", in: tempDir)
+        let editorURL = try makeAppBundle(name: "Editor", bundleIdentifier: "com.test.editor", in: tempDir)
+        let archiveURL = try makeAppBundle(name: "Archive", bundleIdentifier: "com.test.archive", in: tempDir)
+
+        let candidates = RunningAppQuickAdd.candidates(
+            for: [],
+            runningApps: [
+                RunningAppQuickAddSource(bundleIdentifier: "com.test.zebra", bundleURL: zebraURL),
+                RunningAppQuickAddSource(bundleIdentifier: "com.test.editor", bundleURL: editorURL),
+                RunningAppQuickAddSource(bundleIdentifier: "com.test.archive", bundleURL: archiveURL),
+                RunningAppQuickAddSource(bundleIdentifier: "com.test.editor", bundleURL: editorURL)
+            ]
+        )
+
+        XCTAssertEqual(
+            candidates.map(\.bundleIdentifier),
+            ["com.test.archive", "com.test.editor", "com.test.zebra"]
+        )
+    }
+
+    func testRunningAppQuickAddSkipsCandidatesWithoutResolvableBundles() {
+        let candidates = RunningAppQuickAdd.candidates(
+            for: [],
+            runningApps: [RunningAppQuickAddSource(bundleIdentifier: "com.test.missing", bundleURL: nil)]
+        )
+
+        XCTAssertTrue(candidates.isEmpty)
+    }
+
+    private func makeAppBundle(name: String, bundleIdentifier: String, in root: URL) throws -> URL {
+        let appDir = root.appendingPathComponent("\(name).app")
+        let contentsDir = appDir.appendingPathComponent("Contents")
+        try FileManager.default.createDirectory(at: contentsDir, withIntermediateDirectories: true)
+
+        let plist: [String: Any] = [
+            "CFBundleIdentifier": bundleIdentifier,
+            "CFBundleName": name
+        ]
+        let plistData = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try plistData.write(to: contentsDir.appendingPathComponent("Info.plist"))
+
+        return appDir
     }
 }

--- a/ShortcutCycle/ShortcutCycleTests/AppItemTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/AppItemTests.swift
@@ -1,4 +1,3 @@
-import AppKit
 import XCTest
 #if canImport(ShortcutCycleCore)
 @testable import ShortcutCycleCore
@@ -185,7 +184,7 @@ final class AppItemTests: XCTestCase {
                 RunningAppQuickAddSource(bundleIdentifier: "com.xcv58.ShortcutCycle", bundleURL: shortcutCycleURL),
                 RunningAppQuickAddSource(bundleIdentifier: "com.apple.finder", bundleURL: finderURL),
                 RunningAppQuickAddSource(bundleIdentifier: "com.test.mail", bundleURL: mailURL),
-                RunningAppQuickAddSource(bundleIdentifier: "com.test.helper", bundleURL: helperURL, activationPolicy: .accessory),
+                RunningAppQuickAddSource(bundleIdentifier: "com.test.helper", bundleURL: helperURL, isRegularApp: false),
                 RunningAppQuickAddSource(bundleIdentifier: "com.test.browser", bundleURL: browserURL)
             ],
             excludedBundleIdentifiers: ["com.xcv58.ShortcutCycle"]

--- a/ShortcutCycle/ShortcutCycleTests/AppItemTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/AppItemTests.swift
@@ -218,6 +218,26 @@ final class AppItemTests: XCTestCase {
         )
     }
 
+    func testRunningAppQuickAddTieBreaksByBundleIdentifierWhenNamesMatch() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        // "Café" and "Cafe" fold to the same string under .diacriticInsensitive,
+        // triggering the bundle-ID tie-breaker in the sort.
+        let appAURL = try makeAppBundle(name: "Café", bundleIdentifier: "com.test.aaa", in: tempDir)
+        let appZURL = try makeAppBundle(name: "Cafe", bundleIdentifier: "com.test.zzz", in: tempDir)
+
+        let candidates = RunningAppQuickAdd.candidates(
+            for: [],
+            runningApps: [
+                RunningAppQuickAddSource(bundleIdentifier: "com.test.zzz", bundleURL: appZURL),
+                RunningAppQuickAddSource(bundleIdentifier: "com.test.aaa", bundleURL: appAURL)
+            ]
+        )
+
+        XCTAssertEqual(candidates.map(\.bundleIdentifier), ["com.test.aaa", "com.test.zzz"])
+    }
+
     func testRunningAppQuickAddSkipsCandidatesWithoutResolvableBundles() {
         let candidates = RunningAppQuickAdd.candidates(
             for: [],

--- a/ShortcutCycle/ShortcutCycleTests/GroupEditViewTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/GroupEditViewTests.swift
@@ -66,15 +66,6 @@ final class GroupEditViewTests: XCTestCase {
         XCTAssertFalse(GroupEditView.shouldShowRunningAppQuickAddSection([]))
     }
 
-    func testEmptyAppsStateHidesWhenQuickAddCandidatesExist() {
-        XCTAssertTrue(GroupEditView.shouldShowEmptyAppsState(groupApps: []))
-        XCTAssertFalse(
-            GroupEditView.shouldShowEmptyAppsState(
-                groupApps: [AppItem(bundleIdentifier: "com.test.mail", name: "Mail")]
-            )
-        )
-    }
-
     private func hostGroupEditView(
         width: CGFloat,
         height: CGFloat = 600

--- a/ShortcutCycle/ShortcutCycleTests/GroupEditViewTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/GroupEditViewTests.swift
@@ -59,7 +59,26 @@ final class GroupEditViewTests: XCTestCase {
         )
     }
 
-    private func hostGroupEditView(width: CGFloat, height: CGFloat = 600) -> NSHostingView<AnyView> {
+    func testRunningAppsQuickAddSectionVisibilityDependsOnCandidates() {
+        XCTAssertTrue(
+            GroupEditView.shouldShowRunningAppQuickAddSection([AppItem(bundleIdentifier: "com.test.mail", name: "Mail")])
+        )
+        XCTAssertFalse(GroupEditView.shouldShowRunningAppQuickAddSection([]))
+    }
+
+    func testEmptyAppsStateHidesWhenQuickAddCandidatesExist() {
+        XCTAssertTrue(GroupEditView.shouldShowEmptyAppsState(groupApps: []))
+        XCTAssertFalse(
+            GroupEditView.shouldShowEmptyAppsState(
+                groupApps: [AppItem(bundleIdentifier: "com.test.mail", name: "Mail")]
+            )
+        )
+    }
+
+    private func hostGroupEditView(
+        width: CGFloat,
+        height: CGFloat = 600
+    ) -> NSHostingView<AnyView> {
         let groupId = try! XCTUnwrap(store.groups.first?.id)
         let rootView = AnyView(
             GroupEditView(groupId: groupId)

--- a/docs/superpowers/specs/2026-04-04-running-app-quick-add-design.md
+++ b/docs/superpowers/specs/2026-04-04-running-app-quick-add-design.md
@@ -1,0 +1,111 @@
+# Running App Quick Add For Group Editor
+
+## Summary
+
+Add an inline quick-add surface to the group editor that lets users add currently running apps with one click. The goal is to reduce setup friction when the user already has the right apps open, while keeping the existing Finder drag/drop and file-browse flow as the fallback.
+
+## Current Context
+
+The current app-add flow in the group editor depends on `AppDropZoneView`, which supports dragging `.app` bundles from Finder or clicking to browse for applications. That works, but it adds unnecessary friction when the user wants to group apps that are already running.
+
+Issue `#37` asks for a faster app-picking flow, with the strongest direction being a quick-add surface for currently running apps.
+
+## Goals
+
+- Make creating a new group faster when the desired apps are already open
+- Keep the flow local to the existing group editor
+- Support one-click add with no extra modal step
+- Preserve the existing browse and drag/drop path as a secondary option
+- Keep the candidate list predictable and easy to scan
+
+## Non-Goals
+
+- No onboarding wizard, full-screen setup flow, or separate modal picker
+- No search field or recent-app history in V1
+- No Dock drag support in V1
+- No smart classification or automatic grouping suggestions
+- No changes to group persistence or dedupe rules
+
+## Recommended Approach
+
+Show a compact quick-add section directly in `GroupEditView`, above the existing drop zone.
+
+Render the running-app candidates as an inline chip or adaptive grid treatment with app icon and app name. Clicking a candidate should immediately add it to the current group.
+
+The existing `AppDropZoneView` remains visible below this section so that browsing and Finder drag/drop stay available for apps that are not currently running.
+
+### Behavior
+
+- Only show the quick-add section when there is at least one eligible running app candidate
+- Render each candidate once, even if multiple instances of the app are running
+- Clicking a candidate immediately adds it to the current group
+- After add, that candidate disappears from the quick-add list immediately
+- Keep the existing drop zone visible below the quick-add section
+- If no eligible running apps exist, show only the existing drop zone flow
+
+## Candidate Generation
+
+Use the currently running applications list from macOS as the source of truth.
+
+### Selection Rules
+
+- Include only running apps with activation policy `.regular`
+- Exclude `ShortcutCycle` itself
+- Exclude apps already present in the current group
+- Keep Finder eligible if it otherwise qualifies
+- Dedupe candidates by `bundleIdentifier`
+- Only show candidates that can be resolved into a valid `AppItem`
+- Sort candidates alphabetically by app name for predictability
+
+### Resolution Notes
+
+- Exclusion of `ShortcutCycle` should be based on bundle identifier, not display name
+- If a running app cannot be reliably resolved into an `AppItem`, omit it from the quick-add list in V1
+- Candidate sorting should be case-insensitive and diacritic-insensitive so the list feels stable and natural
+
+## Interaction Notes
+
+- The quick-add UI should feel lightweight and immediate, not like a second picker
+- Chips should have a large enough hit target that the user can add several apps quickly
+- The quick-add section should feel like the primary fast path when present
+- The drop zone should remain visually secondary but clearly available for apps that are not running
+
+## Data And Logic Placement
+
+- UI rendering belongs in `GroupEditView`
+- Running-app candidate generation should be implemented as a small, testable helper rather than embedded directly in the view body
+- The helper should take current group membership into account and return resolved `AppItem` candidates ready for the existing add flow
+- The final add action should continue to use the same `store.addApp(...)` path used by the drop zone
+- Existing group-level dedupe by `bundleIdentifier` remains the source of truth
+
+## Edge Cases
+
+- `ShortcutCycle` is running and should never appear as a candidate
+- Finder may appear and should remain eligible
+- Apps already in the current group should never appear in the quick-add list
+- Multi-instance apps, such as browsers with multiple profiles, should appear only once
+- If a candidate disappears from the running-app list while the editor is visible, the UI can simply refresh to the next valid state
+- If every running app is already in the group or otherwise excluded, the quick-add section should stay hidden
+
+## Validation
+
+The implementation should verify:
+
+- the quick-add section appears only when eligible candidates exist
+- `ShortcutCycle` is excluded
+- Finder can appear when eligible
+- apps already in the group are excluded
+- multiple running instances of the same app produce one candidate
+- candidates are sorted alphabetically by name
+- clicking a candidate adds it through the existing app-add path
+- the added app disappears from quick add immediately
+- the existing drag/drop and browse flow still works unchanged
+
+## Open Decisions Resolved
+
+- Use an inline chip or grid treatment rather than a modal sheet
+- Exclude `ShortcutCycle` itself
+- Exclude apps already in the current group
+- Keep Finder eligible
+- Sort candidates alphabetically for predictability
+- Keep the existing browse and drag/drop flow as the fallback path


### PR DESCRIPTION
## Summary
- add a running-app quick-add flow in the group editor with filtering, deduping, and live refresh when apps launch or quit
- separate apps already in the group from add options, keeping running apps and the Finder drop zone visible together with clearer hierarchy
- add tests, localized strings, and the implementation spec for issue #37, plus a safer settings tab symbol

## Why
Closes #37.

Adding apps to a group previously depended on browsing for `.app` bundles or dragging from Finder. This makes common setup slower than it needs to be when the user already has the relevant apps open.

## Validation
- `swift test --filter GroupEditViewTests`
- `swift test --filter GroupSettingsViewTests`
- `swift test --filter LocalizationTests`
- `swift test`
