### PR TITLE
[codex] Add local macOS integration harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ fastlane/test_output
 
 ## Worktrees
 .worktrees/
+.artifacts/
 
 ## macOS specific
 .AppleDB

--- a/ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj
+++ b/ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		017 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 901 /* KeyboardShortcuts */; };
+		A2000012F80000100C0DE01 /* ShortcutCycleIntegrationHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000202F80000100C0DE01 /* ShortcutCycleIntegrationHarness.swift */; };
+		A2000022F80000100C0DE01 /* ShortcutCycleIntegrationTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000212F80000100C0DE01 /* ShortcutCycleIntegrationTestSupport.swift */; };
+		A2000032F80000100C0DE01 /* ShortcutCycleIntegrationHarnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000222F80000100C0DE01 /* ShortcutCycleIntegrationHarnessTests.swift */; };
 		DF88A3762F300B110042E749 /* HUDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3542F300B110042E749 /* HUDManager.swift */; };
 		DF88A3772F300B110042E749 /* ShortcutCycleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3742F300B110042E749 /* ShortcutCycleApp.swift */; };
 		DF88A3782F300B110042E749 /* GroupEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A36D2F300B110042E749 /* GroupEditView.swift */; };
@@ -85,6 +88,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		A2000102F80000100C0DE01 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 600 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 400;
+			remoteInfo = ShortcutCycle;
+		};
 		DF8B47DB2F2F090100C473F8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 600 /* Project object */;
@@ -96,6 +106,10 @@
 
 /* Begin PBXFileReference section */
 		100 /* ShortcutCycle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShortcutCycle.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A2000202F80000100C0DE01 /* ShortcutCycleIntegrationHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCycleIntegrationHarness.swift; sourceTree = "<group>"; };
+		A2000212F80000100C0DE01 /* ShortcutCycleIntegrationTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCycleIntegrationTestSupport.swift; sourceTree = "<group>"; };
+		A2000222F80000100C0DE01 /* ShortcutCycleIntegrationHarnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutCycleIntegrationHarnessTests.swift; sourceTree = "<group>"; };
+		A2000232F80000100C0DE01 /* ShortcutCycleIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShortcutCycleIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DF88A3372F300B110042E749 /* String+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Localization.swift"; sourceTree = "<group>"; };
 		DF88A3392F300B110042E749 /* AppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroup.swift; sourceTree = "<group>"; };
 		DF88A33A2F300B110042E749 /* AppItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppItem.swift; sourceTree = "<group>"; };
@@ -171,6 +185,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A2000502F80000100C0DE01 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -179,6 +200,7 @@
 			children = (
 				DF88A3752F300B110042E749 /* ShortcutCycle */,
 				DF8B47D82F2F090100C473F8 /* ShortcutCycleTests */,
+				A2000312F80000100C0DE01 /* ShortcutCycleIntegrationTests */,
 				302 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -188,8 +210,26 @@
 			children = (
 				100 /* ShortcutCycle.app */,
 				DF8B47D72F2F090100C473F8 /* ShortcutCycleTests.xctest */,
+				A2000232F80000100C0DE01 /* ShortcutCycleIntegrationTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		A2000302F80000100C0DE01 /* Integration */ = {
+			isa = PBXGroup;
+			children = (
+				A2000202F80000100C0DE01 /* ShortcutCycleIntegrationHarness.swift */,
+			);
+			path = Integration;
+			sourceTree = "<group>";
+		};
+		A2000312F80000100C0DE01 /* ShortcutCycleIntegrationTests */ = {
+			isa = PBXGroup;
+			children = (
+				A2000212F80000100C0DE01 /* ShortcutCycleIntegrationTestSupport.swift */,
+				A2000222F80000100C0DE01 /* ShortcutCycleIntegrationHarnessTests.swift */,
+			);
+			path = ShortcutCycleIntegrationTests;
 			sourceTree = "<group>";
 		};
 		DF88A3382F300B110042E749 /* Extensions */ = {
@@ -266,6 +306,7 @@
 			children = (
 				DF88A3522F300B110042E749 /* AppSwitcher */,
 				DF88A3552F300B110042E749 /* HUD */,
+				A2000302F80000100C0DE01 /* Integration */,
 				DF88A3572F300B110042E749 /* Managers */,
 				DF88A3592F300B110042E749 /* Overlay */,
 				E2B200012F50000100C0DE01 /* SettingsWindowLifecycleCoordinator.swift */,
@@ -443,6 +484,26 @@
 			productReference = DF8B47D72F2F090100C473F8 /* ShortcutCycleTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		A2000402F80000100C0DE01 /* ShortcutCycleIntegrationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A2000622F80000100C0DE01 /* Build configuration list for PBXNativeTarget "ShortcutCycleIntegrationTests" */;
+			buildPhases = (
+				A2000522F80000100C0DE01 /* Sources */,
+				A2000502F80000100C0DE01 /* Frameworks */,
+				A2000512F80000100C0DE01 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A2000532F80000100C0DE01 /* PBXTargetDependency */,
+			);
+			name = ShortcutCycleIntegrationTests;
+			packageProductDependencies = (
+			);
+			productName = ShortcutCycleIntegrationTests;
+			productReference = A2000232F80000100C0DE01 /* ShortcutCycleIntegrationTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -454,6 +515,9 @@
 				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					400 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+					A2000402F80000100C0DE01 = {
 						CreatedOnToolsVersion = 15.0;
 					};
 					DF8B47D62F2F090100C473F8 = {
@@ -494,6 +558,7 @@
 			targets = (
 				400 /* ShortcutCycle */,
 				DF8B47D62F2F090100C473F8 /* ShortcutCycleTests */,
+				A2000402F80000100C0DE01 /* ShortcutCycleIntegrationTests */,
 			);
 		};
 /* End PBXProject section */
@@ -517,6 +582,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A2000512F80000100C0DE01 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -533,6 +605,7 @@
 				DF88A3A62F300CA00042E749 /* LaunchAtLoginManager.swift in Sources */,
 				DF88A3A72F300CA00042E749 /* ShortcutManager.swift in Sources */,
 				DF88A3A82F300CA00042E749 /* AppSwitcher.swift in Sources */,
+				A2000012F80000100C0DE01 /* ShortcutCycleIntegrationHarness.swift in Sources */,
 				DF88A39D2F300C800042E749 /* KeyboardShortcutsNames.swift in Sources */,
 				DF88A39E2F300C800042E749 /* AppItem.swift in Sources */,
 				DF88A39F2F300C800042E749 /* GroupStore.swift in Sources */,
@@ -604,9 +677,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A2000522F80000100C0DE01 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A2000022F80000100C0DE01 /* ShortcutCycleIntegrationTestSupport.swift in Sources */,
+				A2000032F80000100C0DE01 /* ShortcutCycleIntegrationHarnessTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		A2000532F80000100C0DE01 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 400 /* ShortcutCycle */;
+			targetProxy = A2000102F80000100C0DE01 /* PBXContainerItemProxy */;
+		};
 		DF8B47DC2F2F090100C473F8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 400 /* ShortcutCycle */;
@@ -778,8 +865,9 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.5;
-				PRODUCT_BUNDLE_IDENTIFIER = com.xcv58.ShortcutCycle;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(SHORTCUTCYCLE_APP_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SHORTCUTCYCLE_APP_BUNDLE_IDENTIFIER = com.xcv58.ShortcutCycle;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};
@@ -807,9 +895,50 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.5;
-				PRODUCT_BUNDLE_IDENTIFIER = com.xcv58.ShortcutCycle;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(SHORTCUTCYCLE_APP_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SHORTCUTCYCLE_APP_BUNDLE_IDENTIFIER = com.xcv58.ShortcutCycle;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		A2000602F80000100C0DE01 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 56;
+				DEVELOPMENT_TEAM = 5736QK4NZX;
+				GENERATE_INFOPLIST_FILE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.5;
+				PRODUCT_BUNDLE_IDENTIFIER = com.xcv58.ShortcutCycleIntegrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		A2000612F80000100C0DE01 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 56;
+				DEVELOPMENT_TEAM = 5736QK4NZX;
+				GENERATE_INFOPLIST_FILE = YES;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.5;
+				PRODUCT_BUNDLE_IDENTIFIER = com.xcv58.ShortcutCycleIntegrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -875,6 +1004,15 @@
 			buildConfigurations = (
 				700 /* Debug */,
 				701 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A2000622F80000100C0DE01 /* Build configuration list for PBXNativeTarget "ShortcutCycleIntegrationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A2000602F80000100C0DE01 /* Debug */,
+				A2000612F80000100C0DE01 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ShortcutCycle/ShortcutCycle.xcodeproj/xcshareddata/xcschemes/ShortcutCycleIntegration.xcscheme
+++ b/ShortcutCycle/ShortcutCycle.xcodeproj/xcshareddata/xcschemes/ShortcutCycleIntegration.xcscheme
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "400"
+               BuildableName = "ShortcutCycle.app"
+               BlueprintName = "ShortcutCycle"
+               ReferencedContainer = "container:ShortcutCycle.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A2000402F80000100C0DE01"
+               BuildableName = "ShortcutCycleIntegrationTests.xctest"
+               BlueprintName = "ShortcutCycleIntegrationTests"
+               ReferencedContainer = "container:ShortcutCycle.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A2000402F80000100C0DE01"
+               BuildableName = "ShortcutCycleIntegrationTests.xctest"
+               BlueprintName = "ShortcutCycleIntegrationTests"
+               ReferencedContainer = "container:ShortcutCycle.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "400"
+            BuildableName = "ShortcutCycle.app"
+            BlueprintName = "ShortcutCycle"
+            ReferencedContainer = "container:ShortcutCycle.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "400"
+            BuildableName = "ShortcutCycle.app"
+            BlueprintName = "ShortcutCycle"
+            ReferencedContainer = "container:ShortcutCycle.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Sync Project Version"
+               scriptText = "set -e&#10;/bin/sh &quot;$SRCROOT/scripts/sync_project_version.sh&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "400"
+                     BuildableName = "ShortcutCycle.app"
+                     BlueprintName = "ShortcutCycle"
+                     ReferencedContainer = "container:ShortcutCycle.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+   </ArchiveAction>
+</Scheme>

--- a/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
@@ -132,6 +132,10 @@ class HUDManager: @preconcurrency ObservableObject {
     var isLooping: Bool {
         return isRepeatingLoopActive
     }
+
+    private var timings: ShortcutCycleIntegrationTimings {
+        ShortcutCycleIntegrationHarness.shared.timings
+    }
     
     // Singleton extraction for testing? 
     // Ideally we should make the constructor accessible for tests, 
@@ -186,7 +190,7 @@ class HUDManager: @preconcurrency ObservableObject {
 
         // Otherwise, schedule show after a short delay (mimic "hold" to show)
         showTimer?.invalidate()
-        showTimer = timerScheduler.schedule(timeInterval: 0.2, repeats: false) { [weak self] _ in // 200ms delay
+        showTimer = timerScheduler.schedule(timeInterval: timings.hudShowDelay, repeats: false) { [weak self] _ in
             Task { @MainActor in
                 self?.closeOffSpaceSettingsWindowIfNeeded()
                 self?.prepareAppForHUDPresentation()
@@ -286,6 +290,7 @@ class HUDManager: @preconcurrency ObservableObject {
         }
 
         window.orderFront(nil)
+        ShortcutCycleIntegrationHarness.shared.recordHUDPresented(activeAppId: activeAppId, items: items)
         // Note: Loop scheduling is handled by scheduleShow() AFTER startMonitoringModifiers(),
         // not here, to ensure isLoopKeyHeld is freshly set before the loop decision.
     }
@@ -297,7 +302,7 @@ class HUDManager: @preconcurrency ObservableObject {
 
         loopTimer?.invalidate()
         // Wait 0.2s after HUD appears before starting the auto-cycle
-        loopTimer = timerScheduler.schedule(timeInterval: 0.2, repeats: false) { [weak self] _ in
+        loopTimer = timerScheduler.schedule(timeInterval: timings.loopStartDelay, repeats: false) { [weak self] _ in
              Task { @MainActor in
                  self?.startRepeatingLoop()
              }
@@ -396,7 +401,7 @@ class HUDManager: @preconcurrency ObservableObject {
         let currentFlags = currentModifierFlags()
         if !checkModifiersHeld(currentFlags: currentFlags, required: required) {
              // Give a tiny grace period for state to settle or for fast release.
-             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+             DispatchQueue.main.asyncAfter(deadline: .now() + timings.modifierReleaseGraceDelay) { [weak self] in
                  guard let self = self else { return }
                  let flags = self.currentModifierFlags()
                  if !self.checkModifiersHeld(currentFlags: flags, required: required) {
@@ -501,7 +506,7 @@ class HUDManager: @preconcurrency ObservableObject {
         loopTimer?.invalidate()
         isRepeatingLoopActive = true
         // Repeat every 125ms
-        loopTimer = timerScheduler.schedule(timeInterval: 0.125, repeats: true) { [weak self] _ in
+        loopTimer = timerScheduler.schedule(timeInterval: timings.repeatLoopInterval, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 self?.selectNextApp()
             }
@@ -677,6 +682,7 @@ class HUDManager: @preconcurrency ObservableObject {
                 closeVisibleSettingsWindowIfNeeded(beforeActivating: pendingId)
             }
             activatePendingTargetApp(pendingId)
+            ShortcutCycleIntegrationHarness.shared.recordSwitchFinalized(targetAppId: pendingId, items: currentItems)
             pendingActiveAppId = nil
         }
         
@@ -749,7 +755,7 @@ class HUDManager: @preconcurrency ObservableObject {
     
     private func scheduleAutoHide() {
         hideTimer?.invalidate()
-        hideTimer = timerScheduler.schedule(timeInterval: 1.0, repeats: false) { [weak self] _ in
+        hideTimer = timerScheduler.schedule(timeInterval: timings.autoHideDelay, repeats: false) { [weak self] _ in
             Task { @MainActor in
                 self?.hide()
             }

--- a/ShortcutCycle/ShortcutCycle/Services/Integration/ShortcutCycleIntegrationHarness.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/Integration/ShortcutCycleIntegrationHarness.swift
@@ -1,0 +1,569 @@
+import AppKit
+import Foundation
+#if canImport(ShortcutCycleCore)
+import ShortcutCycleCore
+#endif
+
+enum ShortcutCycleIntegrationCommandName: String, Codable {
+    case cycle
+}
+
+enum ShortcutCycleIntegrationEventName: String, Codable {
+    case fixtureLoaded
+    case hudPresented
+    case switchFinalized
+    case error
+}
+
+enum ShortcutCycleIntegrationNotification {
+    static func commandName(runId: String) -> Notification.Name {
+        Notification.Name("com.xcv58.ShortcutCycle.Integration.command.\(runId)")
+    }
+
+    static func eventName(runId: String) -> Notification.Name {
+        Notification.Name("com.xcv58.ShortcutCycle.Integration.event.\(runId)")
+    }
+}
+
+enum ShortcutCycleIntegrationUserInfoKey: String {
+    case activeBundleId
+    case command
+    case commandId
+    case event
+    case eventId
+    case groupName
+    case message
+    case runId
+    case timestamp
+}
+
+struct ShortcutCycleIntegrationConfiguration {
+    private static let testModeFlag = "SHORTCUTCYCLE_TEST_MODE"
+    private static let runIDFlag = "SHORTCUTCYCLE_TEST_RUN_ID"
+    private static let fixtureFlag = "SHORTCUTCYCLE_TEST_FIXTURE_PATH"
+    private static let artifactsFlag = "SHORTCUTCYCLE_TEST_ARTIFACTS_DIR"
+
+    let runId: String
+    let fixtureURL: URL
+    let artifactsDirectoryURL: URL
+
+    static func load(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        arguments: [String] = ProcessInfo.processInfo.arguments
+    ) -> ShortcutCycleIntegrationConfiguration? {
+        let argumentValues = parseArguments(arguments)
+
+        func value(for key: String) -> String? {
+            environment[key] ?? argumentValues[key]
+        }
+
+        guard value(for: testModeFlag) == "1",
+              let runId = value(for: runIDFlag),
+              !runId.isEmpty,
+              let fixturePath = value(for: fixtureFlag),
+              !fixturePath.isEmpty,
+              let artifactsPath = value(for: artifactsFlag),
+              !artifactsPath.isEmpty else {
+            return nil
+        }
+
+        return ShortcutCycleIntegrationConfiguration(
+            runId: runId,
+            fixtureURL: URL(fileURLWithPath: fixturePath),
+            artifactsDirectoryURL: URL(fileURLWithPath: artifactsPath, isDirectory: true)
+        )
+    }
+
+    private static func parseArguments(_ arguments: [String]) -> [String: String] {
+        var values: [String: String] = [:]
+
+        for argument in arguments {
+            guard argument.hasPrefix("--"),
+                  let separatorIndex = argument.firstIndex(of: "=") else {
+                continue
+            }
+
+            let key = String(argument[argument.index(argument.startIndex, offsetBy: 2)..<separatorIndex])
+            let valueStart = argument.index(after: separatorIndex)
+            let value = String(argument[valueStart...])
+            values[key] = value
+        }
+
+        return values
+    }
+}
+
+struct ShortcutCycleIntegrationTimings {
+    let hudShowDelay: TimeInterval
+    let loopStartDelay: TimeInterval
+    let repeatLoopInterval: TimeInterval
+    let autoHideDelay: TimeInterval
+    let modifierReleaseGraceDelay: TimeInterval
+
+    static let standard = ShortcutCycleIntegrationTimings(
+        hudShowDelay: 0.2,
+        loopStartDelay: 0.2,
+        repeatLoopInterval: 0.125,
+        autoHideDelay: 1.0,
+        modifierReleaseGraceDelay: 0.05
+    )
+
+    static let integration = ShortcutCycleIntegrationTimings(
+        hudShowDelay: 0.05,
+        loopStartDelay: 0.05,
+        repeatLoopInterval: 0.08,
+        autoHideDelay: 0.25,
+        modifierReleaseGraceDelay: 0.18
+    )
+}
+
+struct ShortcutCycleIntegrationCommand: Codable {
+    let commandId: String
+    let runId: String
+    let command: ShortcutCycleIntegrationCommandName
+    let groupName: String
+
+    init(
+        commandId: String = UUID().uuidString,
+        runId: String,
+        command: ShortcutCycleIntegrationCommandName,
+        groupName: String
+    ) {
+        self.commandId = commandId
+        self.runId = runId
+        self.command = command
+        self.groupName = groupName
+    }
+
+    init?(userInfo: [AnyHashable: Any]?) {
+        guard let commandId = userInfo?[ShortcutCycleIntegrationUserInfoKey.commandId.rawValue] as? String,
+              let runId = userInfo?[ShortcutCycleIntegrationUserInfoKey.runId.rawValue] as? String,
+              let commandRawValue = userInfo?[ShortcutCycleIntegrationUserInfoKey.command.rawValue] as? String,
+              let command = ShortcutCycleIntegrationCommandName(rawValue: commandRawValue),
+              let groupName = userInfo?[ShortcutCycleIntegrationUserInfoKey.groupName.rawValue] as? String else {
+            return nil
+        }
+
+        self.init(commandId: commandId, runId: runId, command: command, groupName: groupName)
+    }
+
+    var userInfo: [String: String] {
+        [
+            ShortcutCycleIntegrationUserInfoKey.commandId.rawValue: commandId,
+            ShortcutCycleIntegrationUserInfoKey.runId.rawValue: runId,
+            ShortcutCycleIntegrationUserInfoKey.command.rawValue: command.rawValue,
+            ShortcutCycleIntegrationUserInfoKey.groupName.rawValue: groupName
+        ]
+    }
+}
+
+struct ShortcutCycleIntegrationEvent: Codable, Equatable {
+    let eventId: String
+    let event: ShortcutCycleIntegrationEventName
+    let runId: String
+    let groupName: String
+    let activeBundleId: String
+    let timestamp: String
+    let message: String?
+
+    init(
+        eventId: String = UUID().uuidString,
+        event: ShortcutCycleIntegrationEventName,
+        runId: String,
+        groupName: String,
+        activeBundleId: String,
+        timestamp: String = ISO8601DateFormatter().string(from: Date()),
+        message: String? = nil
+    ) {
+        self.eventId = eventId
+        self.event = event
+        self.runId = runId
+        self.groupName = groupName
+        self.activeBundleId = activeBundleId
+        self.timestamp = timestamp
+        self.message = message
+    }
+
+    init?(userInfo: [AnyHashable: Any]?) {
+        guard let eventId = userInfo?[ShortcutCycleIntegrationUserInfoKey.eventId.rawValue] as? String,
+              let eventRawValue = userInfo?[ShortcutCycleIntegrationUserInfoKey.event.rawValue] as? String,
+              let event = ShortcutCycleIntegrationEventName(rawValue: eventRawValue),
+              let runId = userInfo?[ShortcutCycleIntegrationUserInfoKey.runId.rawValue] as? String,
+              let groupName = userInfo?[ShortcutCycleIntegrationUserInfoKey.groupName.rawValue] as? String,
+              let activeBundleId = userInfo?[ShortcutCycleIntegrationUserInfoKey.activeBundleId.rawValue] as? String,
+              let timestamp = userInfo?[ShortcutCycleIntegrationUserInfoKey.timestamp.rawValue] as? String else {
+            return nil
+        }
+
+        self.init(
+            eventId: eventId,
+            event: event,
+            runId: runId,
+            groupName: groupName,
+            activeBundleId: activeBundleId,
+            timestamp: timestamp,
+            message: userInfo?[ShortcutCycleIntegrationUserInfoKey.message.rawValue] as? String
+        )
+    }
+
+    var userInfo: [String: String] {
+        var userInfo: [String: String] = [
+            ShortcutCycleIntegrationUserInfoKey.eventId.rawValue: eventId,
+            ShortcutCycleIntegrationUserInfoKey.event.rawValue: event.rawValue,
+            ShortcutCycleIntegrationUserInfoKey.runId.rawValue: runId,
+            ShortcutCycleIntegrationUserInfoKey.groupName.rawValue: groupName,
+            ShortcutCycleIntegrationUserInfoKey.activeBundleId.rawValue: activeBundleId,
+            ShortcutCycleIntegrationUserInfoKey.timestamp.rawValue: timestamp
+        ]
+
+        if let message {
+            userInfo[ShortcutCycleIntegrationUserInfoKey.message.rawValue] = message
+        }
+
+        return userInfo
+    }
+}
+
+@MainActor
+final class ShortcutCycleIntegrationHarness {
+    static let shared = ShortcutCycleIntegrationHarness()
+
+    private let distributedCenter = DistributedNotificationCenter.default()
+    private let fileManager = FileManager.default
+    private let commandLogFileName = "commands.ndjson"
+    private let eventLogFileName = "events.ndjson"
+
+    private var observer: NSObjectProtocol?
+    private var commandPollingTask: Task<Void, Never>?
+    private(set) var configuration = ShortcutCycleIntegrationConfiguration.load()
+    private(set) var isFixtureReady = false
+    private var hasStarted = false
+    private var handledCommandIDs = Set<String>()
+
+    private(set) var currentGroupName = ""
+
+    var isActive: Bool {
+        configuration != nil
+    }
+
+    var timings: ShortcutCycleIntegrationTimings {
+        isActive ? .integration : .standard
+    }
+
+    private init() {}
+
+    func startIfNeeded() {
+        guard let configuration, !hasStarted else { return }
+        hasStarted = true
+
+        prepareArtifactsDirectory(at: configuration.artifactsDirectoryURL)
+        registerDistributedCommandObserver(runId: configuration.runId)
+        startPollingCommandLog(using: configuration)
+        bootstrapFixture(using: configuration)
+    }
+
+    func recordCycleRequest(groupName: String) {
+        guard isActive else { return }
+        currentGroupName = groupName
+    }
+
+    func recordHUDPresented(activeAppId: String, items: [HUDAppItem]) {
+        guard isActive, isFixtureReady else { return }
+        emit(
+            event: .hudPresented,
+            groupName: currentGroupName,
+            activeBundleId: resolvedBundleId(for: activeAppId, items: items)
+        )
+    }
+
+    func recordSwitchFinalized(targetAppId: String, items: [HUDAppItem]) {
+        guard isActive, isFixtureReady else { return }
+
+        let groupName = currentGroupName
+        let targetBundleId = resolvedBundleId(for: targetAppId, items: items)
+
+        Task { @MainActor [weak self] in
+            await self?.emitSwitchFinalized(groupName: groupName, targetBundleId: targetBundleId)
+        }
+    }
+
+    private func bootstrapFixture(using configuration: ShortcutCycleIntegrationConfiguration) {
+        guard fileManager.fileExists(atPath: configuration.fixtureURL.path) else {
+            emitError(
+                "Fixture file not found at \(configuration.fixtureURL.path)",
+                groupName: "",
+                activeBundleId: currentFrontmostBundleId() ?? ""
+            )
+            return
+        }
+
+        let data: Data
+        do {
+            data = try Data(contentsOf: configuration.fixtureURL)
+        } catch {
+            emitError(
+                "Failed to read fixture file at \(configuration.fixtureURL.path): \(error.localizedDescription)",
+                groupName: "",
+                activeBundleId: currentFrontmostBundleId() ?? ""
+            )
+            return
+        }
+
+        switch SettingsExport.validate(data: data) {
+        case .failure(let error):
+            emitError(
+                "Failed to decode fixture file at \(configuration.fixtureURL.path): \(error.localizedDescription)",
+                groupName: "",
+                activeBundleId: currentFrontmostBundleId() ?? ""
+            )
+        case .success(let payload):
+            if let missingBundleId = firstMissingTargetApp(in: payload.groups) {
+                emitError(
+                    "Fixture references a missing target app: \(missingBundleId)",
+                    groupName: payload.groups.first?.name ?? "",
+                    activeBundleId: currentFrontmostBundleId() ?? ""
+                )
+                return
+            }
+
+            GroupStore.shared.applyImport(payload)
+            ShortcutManager.shared.registerAllShortcuts()
+
+            isFixtureReady = true
+            currentGroupName = payload.groups.first?.name ?? ""
+
+            emit(
+                event: .fixtureLoaded,
+                groupName: currentGroupName,
+                activeBundleId: currentFrontmostBundleId() ?? ""
+            )
+        }
+    }
+
+    private func registerDistributedCommandObserver(runId: String) {
+        observer = distributedCenter.addObserver(
+            forName: ShortcutCycleIntegrationNotification.commandName(runId: runId),
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            Task { @MainActor in
+                self?.handleDistributedCommand(notification)
+            }
+        }
+    }
+
+    private func handleDistributedCommand(_ notification: Notification) {
+        guard let configuration,
+              let command = ShortcutCycleIntegrationCommand(userInfo: notification.userInfo),
+              command.runId == configuration.runId else {
+            return
+        }
+
+        handleIncomingCommand(command)
+    }
+
+    private func handleIncomingCommand(_ command: ShortcutCycleIntegrationCommand) {
+        guard handledCommandIDs.insert(command.commandId).inserted else {
+            return
+        }
+
+        switch command.command {
+        case .cycle:
+            handleCycle(groupName: command.groupName)
+        }
+    }
+
+    private func handleCycle(groupName: String) {
+        guard isFixtureReady else {
+            emitError(
+                "Fixture has not finished loading yet",
+                groupName: groupName,
+                activeBundleId: currentFrontmostBundleId() ?? ""
+            )
+            return
+        }
+
+        let store = GroupStore.shared
+        guard let group = store.groups.first(where: { $0.name == groupName }) else {
+            emitError(
+                "Group not found: \(groupName)",
+                groupName: groupName,
+                activeBundleId: currentFrontmostBundleId() ?? ""
+            )
+            return
+        }
+
+        guard group.isEnabled else {
+            emitError(
+                "Group is disabled: \(groupName)",
+                groupName: groupName,
+                activeBundleId: currentFrontmostBundleId() ?? ""
+            )
+            return
+        }
+
+        if let missingBundleId = firstMissingTargetApp(in: [group]) {
+            emitError(
+                "Target app is not installed: \(missingBundleId)",
+                groupName: groupName,
+                activeBundleId: currentFrontmostBundleId() ?? ""
+            )
+            return
+        }
+
+        recordCycleRequest(groupName: groupName)
+        store.selectedGroupId = group.id
+        AppSwitcher.shared.handleShortcut(for: group, store: store)
+    }
+
+    private func emitSwitchFinalized(groupName: String, targetBundleId: String) async {
+        let timeout = Date().addingTimeInterval(3.0)
+
+        while Date() < timeout {
+            if currentFrontmostBundleId() == targetBundleId {
+                emit(
+                    event: .switchFinalized,
+                    groupName: groupName,
+                    activeBundleId: targetBundleId
+                )
+                return
+            }
+
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        emitError(
+            "Timed out waiting for frontmost app to become \(targetBundleId)",
+            groupName: groupName,
+            activeBundleId: currentFrontmostBundleId() ?? targetBundleId
+        )
+    }
+
+    private func emit(
+        event: ShortcutCycleIntegrationEventName,
+        groupName: String,
+        activeBundleId: String,
+        message: String? = nil
+    ) {
+        guard let configuration else { return }
+
+        let integrationEvent = ShortcutCycleIntegrationEvent(
+            event: event,
+            runId: configuration.runId,
+            groupName: groupName,
+            activeBundleId: activeBundleId,
+            message: message
+        )
+
+        appendToEventLog(integrationEvent)
+        distributedCenter.postNotificationName(
+            ShortcutCycleIntegrationNotification.eventName(runId: configuration.runId),
+            object: nil,
+            userInfo: integrationEvent.userInfo,
+            deliverImmediately: true
+        )
+    }
+
+    private func emitError(
+        _ message: String,
+        groupName: String,
+        activeBundleId: String
+    ) {
+        emit(
+            event: .error,
+            groupName: groupName,
+            activeBundleId: activeBundleId,
+            message: message
+        )
+    }
+
+    private func firstMissingTargetApp(in groups: [AppGroup]) -> String? {
+        groups
+            .flatMap(\.apps)
+            .map(\.bundleIdentifier)
+            .first(where: {
+                NSWorkspace.shared.urlForApplication(withBundleIdentifier: $0) == nil
+            })
+    }
+
+    private func resolvedBundleId(for appId: String, items: [HUDAppItem]) -> String {
+        if let match = items.first(where: { $0.id == appId || $0.bundleId == appId }) {
+            return match.bundleId
+        }
+
+        if let bundleId = appId.split(separator: ":").first, !bundleId.isEmpty {
+            return String(bundleId)
+        }
+
+        return appId
+    }
+
+    private func currentFrontmostBundleId() -> String? {
+        NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+    }
+
+    private func prepareArtifactsDirectory(at directoryURL: URL) {
+        do {
+            try fileManager.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            print("ShortcutCycle integration harness failed to create artifacts directory: \(error)")
+        }
+    }
+
+    private func appendToEventLog(_ event: ShortcutCycleIntegrationEvent) {
+        guard let configuration else { return }
+
+        let logURL = configuration.artifactsDirectoryURL.appendingPathComponent(eventLogFileName)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        guard let data = try? encoder.encode(event) else { return }
+
+        if !fileManager.fileExists(atPath: logURL.path) {
+            fileManager.createFile(atPath: logURL.path, contents: nil)
+        }
+
+        do {
+            let handle = try FileHandle(forWritingTo: logURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+            try handle.write(contentsOf: Data([0x0A]))
+        } catch {
+            print("ShortcutCycle integration harness failed to append event log: \(error)")
+        }
+    }
+
+    private func startPollingCommandLog(using configuration: ShortcutCycleIntegrationConfiguration) {
+        guard commandPollingTask == nil else { return }
+
+        let commandLogURL = configuration.artifactsDirectoryURL.appendingPathComponent(commandLogFileName)
+        commandPollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.pollCommandLog(at: commandLogURL, runId: configuration.runId)
+                try? await Task.sleep(nanoseconds: 50_000_000)
+            }
+        }
+    }
+
+    private func pollCommandLog(at logURL: URL, runId: String) {
+        guard let data = try? Data(contentsOf: logURL),
+              let contents = String(data: data, encoding: .utf8),
+              !contents.isEmpty else {
+            return
+        }
+
+        let decoder = JSONDecoder()
+        for line in contents.split(whereSeparator: \.isNewline) {
+            guard let lineData = line.data(using: .utf8),
+                  let command = try? decoder.decode(ShortcutCycleIntegrationCommand.self, from: lineData),
+                  command.runId == runId else {
+                continue
+            }
+            handleIncomingCommand(command)
+        }
+    }
+}

--- a/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
+++ b/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
@@ -673,7 +673,9 @@ struct ShortcutCycleApp: App {
     init() {
         // Setup shortcut manager
         Task { @MainActor in
-            ShortcutManager.shared.registerAllShortcuts()
+            if !ShortcutCycleIntegrationHarness.shared.isActive {
+                ShortcutManager.shared.registerAllShortcuts()
+            }
         }
     }
 
@@ -737,6 +739,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard !flag else { return false }
         ShortcutCycleURLRouter.openSettingsFromOutsideView()
         return true
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        ShortcutCycleIntegrationHarness.shared.startIfNeeded()
     }
 
     @objc private func handleURLEvent(

--- a/ShortcutCycle/ShortcutCycleIntegrationFixtures/IntegrationHUD.settings.json
+++ b/ShortcutCycle/ShortcutCycleIntegrationFixtures/IntegrationHUD.settings.json
@@ -1,0 +1,37 @@
+{
+  "exportDate" : "2026-04-04T00:00:00Z",
+  "groups" : [
+    {
+      "apps" : [
+        {
+          "bundleIdentifier" : "com.apple.calculator",
+          "id" : "00000000-0000-4000-8000-000000000002",
+          "name" : "Calculator"
+        },
+        {
+          "bundleIdentifier" : "com.apple.Chess",
+          "id" : "00000000-0000-4000-8000-000000000003",
+          "name" : "Chess"
+        }
+      ],
+      "id" : "00000000-0000-4000-8000-000000000001",
+      "isEnabled" : true,
+      "lastModified" : "2026-04-04T00:00:00Z",
+      "name" : "Integration HUD",
+      "openAppIfNeeded" : false
+    }
+  ],
+  "settings" : {
+    "appTheme" : "system",
+    "selectedLanguage" : "system",
+    "showHUD" : true,
+    "showShortcutInHUD" : true
+  },
+  "shortcuts" : {
+    "00000000-0000-4000-8000-000000000001" : {
+      "carbonKeyCode" : 18,
+      "carbonModifiers" : 2048
+    }
+  },
+  "version" : 3
+}

--- a/ShortcutCycle/ShortcutCycleIntegrationTests/ShortcutCycleIntegrationHarnessTests.swift
+++ b/ShortcutCycle/ShortcutCycleIntegrationTests/ShortcutCycleIntegrationHarnessTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+
+private struct IntegrationFixture: Codable {
+    var exportDate: String
+    var groups: [IntegrationFixtureGroup]
+    var settings: IntegrationFixtureSettings?
+    var shortcuts: [String: IntegrationFixtureShortcut]?
+    var version: Int
+}
+
+private struct IntegrationFixtureGroup: Codable {
+    var apps: [IntegrationFixtureApp]
+    var id: String
+    var isEnabled: Bool
+    var lastModified: String
+    var name: String
+    var openAppIfNeeded: Bool?
+}
+
+private struct IntegrationFixtureApp: Codable {
+    var bundleIdentifier: String
+    var id: String
+    var name: String
+    var iconPath: String?
+}
+
+private struct IntegrationFixtureSettings: Codable {
+    var appTheme: String?
+    var selectedLanguage: String?
+    var showHUD: Bool
+    var showShortcutInHUD: Bool
+}
+
+private struct IntegrationFixtureShortcut: Codable {
+    var carbonKeyCode: Int
+    var carbonModifiers: Int
+}
+
+@MainActor
+final class ShortcutCycleIntegrationHappyPathTests: ShortcutCycleIntegrationTestCase {
+    func testThreeCycleHUDScenario() async throws {
+        let session = makeSession(
+            artifactSubdirectory: "happy-path",
+            fixtureURL: validFixtureURL
+        )
+
+        try await session.launch()
+        _ = try await session.waitForEvent(.fixtureLoaded)
+        try await session.activateFinder()
+
+        let expectedBundleIDs = [
+            "com.apple.calculator",
+            "com.apple.Chess",
+            "com.apple.calculator"
+        ]
+
+        var savedFrames: [URL] = []
+
+        for (index, expectedBundleID) in expectedBundleIDs.enumerated() {
+            let cycleNumber = index + 1
+            session.sendCycle(groupName: "Integration HUD")
+
+            let hudEvent = try await session.waitForEvent(.hudPresented)
+            XCTAssertEqual(hudEvent.groupName, "Integration HUD")
+            savedFrames.append(try session.captureFrame(label: "cycle\(cycleNumber)-hud"))
+
+            let finalizedEvent = try await session.waitForEvent(.switchFinalized)
+            XCTAssertEqual(finalizedEvent.groupName, "Integration HUD")
+            XCTAssertEqual(finalizedEvent.activeBundleId, expectedBundleID)
+            try await session.waitUntilFrontmostBundleIdentifier(expectedBundleID)
+            XCTAssertEqual(session.currentFrontmostBundleIdentifier(), expectedBundleID)
+            savedFrames.append(try session.captureFrame(label: "cycle\(cycleNumber)-final"))
+        }
+
+        XCTAssertEqual(savedFrames.count, 6)
+        for frame in savedFrames {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: frame.path))
+        }
+    }
+}
+
+@MainActor
+final class ShortcutCycleIntegrationHarnessFailureTests: ShortcutCycleIntegrationTestCase {
+    func testMissingFixtureEmitsClearErrorEvent() async throws {
+        let missingFixtureURL = runRootURL.appendingPathComponent("missing-fixture.json", isDirectory: false)
+        let session = makeSession(
+            artifactSubdirectory: "failure-missing-fixture",
+            fixtureURL: missingFixtureURL
+        )
+
+        try await session.launch()
+        let errorEvent = try await session.waitForEvent(.error, failOnError: false)
+
+        XCTAssertEqual(errorEvent.groupName, "")
+        XCTAssertTrue(errorEvent.message?.contains("Fixture file not found") == true)
+    }
+
+    func testMissingTargetAppEmitsClearErrorEvent() async throws {
+        let brokenFixtureURL = try makeFixtureWithMissingTargetApp(
+            destinationURL: runRootURL.appendingPathComponent("missing-target-app.json", isDirectory: false)
+        )
+        let session = makeSession(
+            artifactSubdirectory: "failure-missing-target-app",
+            fixtureURL: brokenFixtureURL
+        )
+
+        try await session.launch()
+        let errorEvent = try await session.waitForEvent(.error, failOnError: false)
+
+        XCTAssertEqual(errorEvent.groupName, "Integration HUD")
+        XCTAssertTrue(errorEvent.message?.contains("Fixture references a missing target app") == true)
+        XCTAssertTrue(errorEvent.message?.contains("com.apple.ShortcutCycleIntegration.MissingApp") == true)
+    }
+
+    private func makeFixtureWithMissingTargetApp(destinationURL: URL) throws -> URL {
+        let data = try Data(contentsOf: validFixtureURL)
+
+        let decoder = JSONDecoder()
+        let export = try decoder.decode(IntegrationFixture.self, from: data)
+
+        var groups = export.groups
+        var brokenGroup = try XCTUnwrap(groups.first)
+        let firstApp = try XCTUnwrap(brokenGroup.apps.first)
+        brokenGroup.apps[0] = IntegrationFixtureApp(
+            bundleIdentifier: "com.apple.ShortcutCycleIntegration.MissingApp",
+            id: firstApp.id,
+            name: "Missing App",
+            iconPath: firstApp.iconPath
+        )
+        groups[0] = brokenGroup
+
+        let rewrittenExport = IntegrationFixture(
+            exportDate: export.exportDate,
+            groups: groups,
+            settings: export.settings,
+            shortcuts: export.shortcuts,
+            version: export.version
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+
+        let directoryURL = destinationURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try encoder.encode(rewrittenExport).write(to: destinationURL, options: .atomic)
+        return destinationURL
+    }
+}

--- a/ShortcutCycle/ShortcutCycleIntegrationTests/ShortcutCycleIntegrationTestSupport.swift
+++ b/ShortcutCycle/ShortcutCycleIntegrationTests/ShortcutCycleIntegrationTestSupport.swift
@@ -1,0 +1,739 @@
+import AppKit
+import CoreGraphics
+import XCTest
+
+enum ShortcutCycleIntegrationEventName: String, Codable {
+    case fixtureLoaded
+    case hudPresented
+    case switchFinalized
+    case error
+}
+
+enum ShortcutCycleIntegrationCommandName: String, Codable {
+    case cycle
+}
+
+enum ShortcutCycleIntegrationNotification {
+    static func commandName(runId: String) -> Notification.Name {
+        Notification.Name("com.xcv58.ShortcutCycle.Integration.command.\(runId)")
+    }
+
+    static func eventName(runId: String) -> Notification.Name {
+        Notification.Name("com.xcv58.ShortcutCycle.Integration.event.\(runId)")
+    }
+}
+
+enum ShortcutCycleIntegrationUserInfoKey: String {
+    case activeBundleId
+    case command
+    case commandId
+    case event
+    case eventId
+    case groupName
+    case message
+    case runId
+    case timestamp
+}
+
+struct ShortcutCycleIntegrationCommand: Codable {
+    let commandId: String
+    let runId: String
+    let command: ShortcutCycleIntegrationCommandName
+    let groupName: String
+
+    init(
+        commandId: String = UUID().uuidString,
+        runId: String,
+        command: ShortcutCycleIntegrationCommandName,
+        groupName: String
+    ) {
+        self.commandId = commandId
+        self.runId = runId
+        self.command = command
+        self.groupName = groupName
+    }
+
+    var userInfo: [String: String] {
+        [
+            ShortcutCycleIntegrationUserInfoKey.commandId.rawValue: commandId,
+            ShortcutCycleIntegrationUserInfoKey.runId.rawValue: runId,
+            ShortcutCycleIntegrationUserInfoKey.command.rawValue: command.rawValue,
+            ShortcutCycleIntegrationUserInfoKey.groupName.rawValue: groupName
+        ]
+    }
+}
+
+struct ShortcutCycleIntegrationEvent: Codable, Equatable {
+    let eventId: String
+    let event: ShortcutCycleIntegrationEventName
+    let runId: String
+    let groupName: String
+    let activeBundleId: String
+    let timestamp: String
+    let message: String?
+
+    init?(userInfo: [AnyHashable: Any]?) {
+        guard let eventId = userInfo?[ShortcutCycleIntegrationUserInfoKey.eventId.rawValue] as? String,
+              let eventRawValue = userInfo?[ShortcutCycleIntegrationUserInfoKey.event.rawValue] as? String,
+              let event = ShortcutCycleIntegrationEventName(rawValue: eventRawValue),
+              let runId = userInfo?[ShortcutCycleIntegrationUserInfoKey.runId.rawValue] as? String,
+              let groupName = userInfo?[ShortcutCycleIntegrationUserInfoKey.groupName.rawValue] as? String,
+              let activeBundleId = userInfo?[ShortcutCycleIntegrationUserInfoKey.activeBundleId.rawValue] as? String,
+              let timestamp = userInfo?[ShortcutCycleIntegrationUserInfoKey.timestamp.rawValue] as? String else {
+            return nil
+        }
+
+        self.eventId = eventId
+        self.event = event
+        self.runId = runId
+        self.groupName = groupName
+        self.activeBundleId = activeBundleId
+        self.timestamp = timestamp
+        self.message = userInfo?[ShortcutCycleIntegrationUserInfoKey.message.rawValue] as? String
+    }
+}
+
+@MainActor
+final class ShortcutCycleIntegrationSession {
+    private let fileManager = FileManager.default
+    private let distributedCenter = DistributedNotificationCenter.default()
+    private let appURL: URL
+    private let fixtureURL: URL
+    private let artifactsURL: URL
+    private let appBundleIdentifier: String
+
+    private var observer: NSObjectProtocol?
+    private var observedEventIDs = Set<String>()
+    private var bufferedEvents: [ShortcutCycleIntegrationEvent] = []
+
+    private(set) var launchedApp: NSRunningApplication?
+    private(set) var frameIndex = 0
+
+    let runId = UUID().uuidString
+
+    init(
+        appURL: URL,
+        fixtureURL: URL,
+        artifactsURL: URL,
+        appBundleIdentifier: String
+    ) {
+        self.appURL = appURL
+        self.fixtureURL = fixtureURL
+        self.artifactsURL = artifactsURL
+        self.appBundleIdentifier = appBundleIdentifier
+    }
+
+    var framesDirectoryURL: URL {
+        artifactsURL.appendingPathComponent("frames", isDirectory: true)
+    }
+
+    var harnessDirectoryURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Containers/\(appBundleIdentifier)/Data/Library/Application Support/ShortcutCycle/IntegrationHarness/\(runId)", isDirectory: true)
+    }
+
+    var launchFixtureURL: URL {
+        harnessDirectoryURL.appendingPathComponent("fixture.json", isDirectory: false)
+    }
+
+    var commandLogURL: URL {
+        harnessDirectoryURL.appendingPathComponent("commands.ndjson", isDirectory: false)
+    }
+
+    var eventLogURL: URL {
+        harnessDirectoryURL.appendingPathComponent("events.ndjson", isDirectory: false)
+    }
+
+    func launch() async throws {
+        try resetArtifactsDirectory()
+        try stageLaunchInputs()
+        startObservingEvents()
+        await terminateRunningIntegrationApps()
+
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = false
+        if #available(macOS 13.0, *) {
+            configuration.createsNewApplicationInstance = true
+        }
+        configuration.environment = [
+            "SHORTCUTCYCLE_TEST_MODE": "1",
+            "SHORTCUTCYCLE_TEST_RUN_ID": runId,
+            "SHORTCUTCYCLE_TEST_FIXTURE_PATH": launchFixtureURL.path,
+            "SHORTCUTCYCLE_TEST_ARTIFACTS_DIR": harnessDirectoryURL.path
+        ]
+        configuration.arguments = [
+            "--SHORTCUTCYCLE_TEST_MODE=1",
+            "--SHORTCUTCYCLE_TEST_RUN_ID=\(runId)",
+            "--SHORTCUTCYCLE_TEST_FIXTURE_PATH=\(launchFixtureURL.path)",
+            "--SHORTCUTCYCLE_TEST_ARTIFACTS_DIR=\(harnessDirectoryURL.path)"
+        ]
+
+        launchedApp = try await withCheckedThrowingContinuation { continuation in
+            NSWorkspace.shared.openApplication(at: appURL, configuration: configuration) { app, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+
+                guard let app else {
+                    continuation.resume(
+                        throwing: NSError(
+                            domain: "ShortcutCycleIntegration",
+                            code: 1,
+                            userInfo: [NSLocalizedDescriptionKey: "App launch completed without returning a running application instance."]
+                        )
+                    )
+                    return
+                }
+
+                continuation.resume(returning: app)
+            }
+        }
+    }
+
+    func terminate() async {
+        if let observer {
+            distributedCenter.removeObserver(observer)
+            self.observer = nil
+        }
+
+        await terminateRunningIntegrationApps()
+    }
+
+    func sendCycle(groupName: String) {
+        let command = ShortcutCycleIntegrationCommand(
+            runId: runId,
+            command: .cycle,
+            groupName: groupName
+        )
+
+        distributedCenter.postNotificationName(
+            ShortcutCycleIntegrationNotification.commandName(runId: runId),
+            object: nil,
+            userInfo: command.userInfo,
+            deliverImmediately: true
+        )
+
+        appendCommandToLog(command)
+    }
+
+    func waitForEvent(
+        _ expectedEvent: ShortcutCycleIntegrationEventName,
+        timeout: TimeInterval = 5.0,
+        failOnError: Bool = true
+    ) async throws -> ShortcutCycleIntegrationEvent {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            loadEventsFromLogIfNeeded()
+
+            if let event = dequeueEvent(expectedEvent: expectedEvent, failOnError: failOnError) {
+                if failOnError, event.event == .error {
+                    throw NSError(
+                        domain: "ShortcutCycleIntegration",
+                        code: 6,
+                        userInfo: [NSLocalizedDescriptionKey: event.message ?? "Integration harness emitted an unspecified error."]
+                    )
+                }
+                return event
+            }
+
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        throw NSError(
+            domain: "ShortcutCycleIntegration",
+            code: 2,
+            userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for \(expectedEvent.rawValue)"]
+        )
+    }
+
+    func captureFrame(label: String) throws -> URL {
+        try fileManager.createDirectory(at: framesDirectoryURL, withIntermediateDirectories: true)
+
+        let displayID = preferredCaptureDisplayID(for: label)
+
+        guard let image = CGDisplayCreateImage(displayID) else {
+            throw NSError(
+                domain: "ShortcutCycleIntegration",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "Unable to capture the selected display. Screen Recording permission may be required."]
+            )
+        }
+
+        let bitmap = NSBitmapImageRep(cgImage: image)
+        guard let pngData = bitmap.representation(using: .png, properties: [:]) else {
+            throw NSError(
+                domain: "ShortcutCycleIntegration",
+                code: 4,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to encode screenshot as PNG."]
+            )
+        }
+
+        frameIndex += 1
+        let fileName = String(format: "frame-%04d-%@.png", frameIndex, sanitize(label))
+        let destinationURL = framesDirectoryURL.appendingPathComponent(fileName, isDirectory: false)
+        try pngData.write(to: destinationURL, options: .atomic)
+        return destinationURL
+    }
+
+    private func preferredCaptureDisplayID(for label: String) -> CGDirectDisplayID {
+        let lowercasedLabel = label.lowercased()
+
+        if lowercasedLabel.contains("hud"),
+           let launchedApp,
+           let displayID = displayIDForLargestVisibleWindow(ownerPID: launchedApp.processIdentifier) {
+            return displayID
+        }
+
+        if let frontmostApplication = NSWorkspace.shared.frontmostApplication,
+           frontmostApplication.bundleIdentifier != appBundleIdentifier,
+           let displayID = displayIDForLargestVisibleWindow(ownerPID: frontmostApplication.processIdentifier) {
+            return displayID
+        }
+
+        if let launchedApp,
+           let displayID = displayIDForLargestVisibleWindow(ownerPID: launchedApp.processIdentifier) {
+            return displayID
+        }
+
+        return fallbackCaptureDisplayID()
+    }
+
+    private func displayIDForLargestVisibleWindow(ownerPID: pid_t) -> CGDirectDisplayID? {
+        guard let windowList = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly, .excludeDesktopElements],
+            kCGNullWindowID
+        ) as? [[String: Any]] else {
+            return nil
+        }
+
+        let candidateBounds = windowList
+            .filter { window in
+                guard let pid = window[kCGWindowOwnerPID as String] as? pid_t,
+                      pid == ownerPID else {
+                    return false
+                }
+
+                let isOnscreen = (window[kCGWindowIsOnscreen as String] as? Int) ?? 1
+                let alpha = (window[kCGWindowAlpha as String] as? Double) ?? 1
+                return isOnscreen == 1 && alpha > 0
+            }
+            .compactMap(windowBounds(from:))
+            .filter { bounds in
+                bounds.width >= 80 && bounds.height >= 80
+            }
+            .max { lhs, rhs in
+                lhs.width * lhs.height < rhs.width * rhs.height
+            }
+
+        guard let candidateBounds else {
+            return nil
+        }
+
+        return displayIDContainingMost(of: candidateBounds)
+    }
+
+    private func displayIDContainingMost(of bounds: CGRect) -> CGDirectDisplayID? {
+        let displays = activeDisplayIDs()
+        guard !displays.isEmpty else {
+            return nil
+        }
+
+        let bestMatch = displays.max { lhs, rhs in
+            intersectionArea(between: bounds, and: CGDisplayBounds(lhs)) <
+                intersectionArea(between: bounds, and: CGDisplayBounds(rhs))
+        }
+
+        if let bestMatch,
+           intersectionArea(between: bounds, and: CGDisplayBounds(bestMatch)) > 0 {
+            return bestMatch
+        }
+
+        let center = CGPoint(x: bounds.midX, y: bounds.midY)
+        return displays.first(where: { CGDisplayBounds($0).contains(center) })
+    }
+
+    private func fallbackCaptureDisplayID() -> CGDirectDisplayID {
+        if let primaryScreenID = displayID(for: NSScreen.screens.first),
+           CGDisplayIsBuiltin(primaryScreenID) == 0 {
+            return primaryScreenID
+        }
+
+        if let mainScreenID = displayID(for: NSScreen.main),
+           CGDisplayIsBuiltin(mainScreenID) == 0 {
+            return mainScreenID
+        }
+
+        if let externalDisplayID = activeDisplayIDs().first(where: { CGDisplayIsBuiltin($0) == 0 }) {
+            return externalDisplayID
+        }
+
+        return displayID(for: NSScreen.main) ??
+            displayID(for: NSScreen.screens.first) ??
+            CGMainDisplayID()
+    }
+
+    private func activeDisplayIDs() -> [CGDirectDisplayID] {
+        var displayCount: UInt32 = 0
+        guard CGGetActiveDisplayList(0, nil, &displayCount) == .success,
+              displayCount > 0 else {
+            return []
+        }
+
+        var displayIDs = Array(repeating: CGDirectDisplayID(), count: Int(displayCount))
+        guard CGGetActiveDisplayList(displayCount, &displayIDs, &displayCount) == .success else {
+            return []
+        }
+
+        return Array(displayIDs.prefix(Int(displayCount)))
+    }
+
+    private func displayID(for screen: NSScreen?) -> CGDirectDisplayID? {
+        guard let screen,
+              let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
+            return nil
+        }
+
+        return CGDirectDisplayID(screenNumber.uint32Value)
+    }
+
+    private func windowBounds(from window: [String: Any]) -> CGRect? {
+        guard let boundsDictionary = window[kCGWindowBounds as String] as? NSDictionary else {
+            return nil
+        }
+
+        var bounds = CGRect.null
+        guard CGRectMakeWithDictionaryRepresentation(boundsDictionary, &bounds) else {
+            return nil
+        }
+
+        return bounds
+    }
+
+    private func intersectionArea(between lhs: CGRect, and rhs: CGRect) -> CGFloat {
+        let intersection = lhs.intersection(rhs)
+        guard !intersection.isNull else {
+            return 0
+        }
+
+        return intersection.width * intersection.height
+    }
+
+    func activateFinder() async throws {
+        guard let finder = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.finder").first else {
+            throw NSError(
+                domain: "ShortcutCycleIntegration",
+                code: 5,
+                userInfo: [NSLocalizedDescriptionKey: "Finder is not available for neutral-state activation."]
+            )
+        }
+
+        if #available(macOS 14.0, *) {
+            _ = finder.activate(from: .current, options: [.activateAllWindows])
+        } else {
+            _ = finder.activate(options: [.activateAllWindows])
+        }
+        try await waitUntil(
+            description: "Finder to become frontmost",
+            timeout: 2.0
+        ) { [weak self] in
+            self?.currentFrontmostBundleIdentifier() == "com.apple.finder"
+        }
+    }
+
+    func currentFrontmostBundleIdentifier() -> String? {
+        NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+    }
+
+    func waitUntilFrontmostBundleIdentifier(
+        _ bundleIdentifier: String,
+        timeout: TimeInterval = 3.0
+    ) async throws {
+        try await waitUntil(
+            description: "\(bundleIdentifier) to become frontmost",
+            timeout: timeout
+        ) { [weak self] in
+            self?.currentFrontmostBundleIdentifier() == bundleIdentifier
+        }
+    }
+
+    private func startObservingEvents() {
+        guard observer == nil else { return }
+
+        observer = distributedCenter.addObserver(
+            forName: ShortcutCycleIntegrationNotification.eventName(runId: runId),
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let event = ShortcutCycleIntegrationEvent(userInfo: notification.userInfo) else {
+                return
+            }
+
+            Task { @MainActor [weak self] in
+                self?.appendEvent(event)
+            }
+        }
+    }
+
+    private func appendEvent(_ event: ShortcutCycleIntegrationEvent) {
+        guard observedEventIDs.insert(event.eventId).inserted else { return }
+        bufferedEvents.append(event)
+    }
+
+    private func loadEventsFromLogIfNeeded() {
+        guard let data = try? Data(contentsOf: eventLogURL),
+              let contents = String(data: data, encoding: .utf8),
+              !contents.isEmpty else {
+            return
+        }
+
+        let decoder = JSONDecoder()
+        for line in contents.split(whereSeparator: \.isNewline) {
+            guard let lineData = line.data(using: .utf8),
+                  let event = try? decoder.decode(ShortcutCycleIntegrationEvent.self, from: lineData) else {
+                continue
+            }
+            appendEvent(event)
+        }
+    }
+
+    private func dequeueEvent(
+        expectedEvent: ShortcutCycleIntegrationEventName,
+        failOnError: Bool
+    ) -> ShortcutCycleIntegrationEvent? {
+        guard let index = bufferedEvents.firstIndex(where: {
+            $0.event == expectedEvent || (failOnError && $0.event == .error)
+        }) else {
+            return nil
+        }
+
+        let event = bufferedEvents.remove(at: index)
+        return event
+    }
+
+    private func waitUntil(
+        description: String,
+        timeout: TimeInterval,
+        condition: @escaping () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            if condition() {
+                return
+            }
+
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        throw NSError(
+            domain: "ShortcutCycleIntegration",
+            code: 7,
+            userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for \(description)."]
+        )
+    }
+
+    private func terminateRunningIntegrationApps() async {
+        let runningApps = NSRunningApplication.runningApplications(withBundleIdentifier: appBundleIdentifier)
+        guard !runningApps.isEmpty else { return }
+
+        for app in runningApps {
+            app.terminate()
+        }
+
+        let deadline = Date().addingTimeInterval(5.0)
+        while Date() < deadline {
+            let activeApps = NSRunningApplication.runningApplications(withBundleIdentifier: appBundleIdentifier)
+            if activeApps.isEmpty {
+                launchedApp = nil
+                return
+            }
+
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        for app in NSRunningApplication.runningApplications(withBundleIdentifier: appBundleIdentifier) {
+            app.forceTerminate()
+        }
+        launchedApp = nil
+    }
+
+    private func resetArtifactsDirectory() throws {
+        if fileManager.fileExists(atPath: artifactsURL.path) {
+            try fileManager.removeItem(at: artifactsURL)
+        }
+        try fileManager.createDirectory(at: artifactsURL, withIntermediateDirectories: true)
+    }
+
+    private func stageLaunchInputs() throws {
+        if fileManager.fileExists(atPath: harnessDirectoryURL.path) {
+            try fileManager.removeItem(at: harnessDirectoryURL)
+        }
+        try fileManager.createDirectory(at: harnessDirectoryURL, withIntermediateDirectories: true)
+
+        if fileManager.fileExists(atPath: fixtureURL.path) {
+            try fileManager.copyItem(at: fixtureURL, to: launchFixtureURL)
+        }
+    }
+
+    private func appendCommandToLog(_ command: ShortcutCycleIntegrationCommand) {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+
+        guard let data = try? encoder.encode(command) else {
+            return
+        }
+
+        if !fileManager.fileExists(atPath: commandLogURL.path) {
+            fileManager.createFile(atPath: commandLogURL.path, contents: nil)
+        }
+
+        do {
+            let handle = try FileHandle(forWritingTo: commandLogURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+            try handle.write(contentsOf: Data([0x0A]))
+        } catch {
+            XCTFail("Failed to append integration command log: \(error.localizedDescription)")
+        }
+    }
+
+    private func sanitize(_ label: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-"))
+        let scalars = label.lowercased().unicodeScalars.map { scalar -> Character in
+            allowed.contains(scalar) ? Character(scalar) : "-"
+        }
+        return String(scalars)
+            .replacingOccurrences(of: "--", with: "-")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+}
+
+@MainActor
+class ShortcutCycleIntegrationTestCase: XCTestCase {
+    private struct RuntimeContext {
+        let appURL: URL
+        let validFixtureURL: URL
+        let runRootURL: URL
+        let appBundleIdentifier: String
+    }
+
+    private static let sourceFileURL = URL(fileURLWithPath: #filePath)
+    private static let projectRootURL = sourceFileURL
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+    private static let repoRootURL = projectRootURL.deletingLastPathComponent()
+    private static let contextFileURL = repoRootURL
+        .appendingPathComponent(".artifacts/xcode-integration/integration-context.env", isDirectory: false)
+
+    private(set) var appURL: URL!
+    private(set) var validFixtureURL: URL!
+    private(set) var runRootURL: URL!
+    private(set) var appBundleIdentifier: String!
+
+    private var sessions: [ShortcutCycleIntegrationSession] = []
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
+
+        let runtimeContext = try resolveRuntimeContext()
+        appURL = runtimeContext.appURL
+        validFixtureURL = runtimeContext.validFixtureURL
+        runRootURL = runtimeContext.runRootURL
+        appBundleIdentifier = runtimeContext.appBundleIdentifier
+    }
+
+    override func tearDown() async throws {
+        for session in sessions.reversed() {
+            await session.terminate()
+        }
+        sessions.removeAll()
+        try await super.tearDown()
+    }
+
+    func makeSession(
+        artifactSubdirectory: String,
+        fixtureURL: URL
+    ) -> ShortcutCycleIntegrationSession {
+        let session = ShortcutCycleIntegrationSession(
+            appURL: appURL,
+            fixtureURL: fixtureURL,
+            artifactsURL: runRootURL.appendingPathComponent(artifactSubdirectory, isDirectory: true),
+            appBundleIdentifier: appBundleIdentifier
+        )
+        sessions.append(session)
+        return session
+    }
+
+    private func resolveRuntimeContext() throws -> RuntimeContext {
+        let environment = ProcessInfo.processInfo.environment
+        let fileContext = loadContextFile()
+        let testBundleProductsURL = Bundle(for: type(of: self)).bundleURL.deletingLastPathComponent()
+
+        let defaultAppURL = testBundleProductsURL.appendingPathComponent("ShortcutCycle.app", isDirectory: true)
+        let defaultFixtureURL = Self.projectRootURL
+            .appendingPathComponent("ShortcutCycleIntegrationFixtures/IntegrationHUD.settings.json", isDirectory: false)
+        let defaultRunRootURL = Self.repoRootURL
+            .appendingPathComponent(".artifacts/integration/fallback", isDirectory: true)
+
+        func contextValue(_ key: String) -> String? {
+            environment[key] ?? fileContext[key]
+        }
+
+        let appURL = URL(
+            fileURLWithPath: contextValue("SHORTCUTCYCLE_INTEGRATION_APP_PATH") ?? defaultAppURL.path,
+            isDirectory: true
+        )
+        let validFixtureURL = URL(
+            fileURLWithPath: contextValue("SHORTCUTCYCLE_INTEGRATION_VALID_FIXTURE_PATH") ?? defaultFixtureURL.path,
+            isDirectory: false
+        )
+        let runRootURL = URL(
+            fileURLWithPath: contextValue("SHORTCUTCYCLE_INTEGRATION_RUN_ROOT") ?? defaultRunRootURL.path,
+            isDirectory: true
+        )
+        let appBundleIdentifier = contextValue("SHORTCUTCYCLE_INTEGRATION_APP_BUNDLE_ID") ?? "com.xcv58.ShortcutCycle.Integration"
+
+        guard FileManager.default.fileExists(atPath: appURL.path) else {
+            throw NSError(
+                domain: "ShortcutCycleIntegration",
+                code: 8,
+                userInfo: [NSLocalizedDescriptionKey: "Expected integration app at \(appURL.path)."]
+            )
+        }
+
+        guard FileManager.default.fileExists(atPath: validFixtureURL.path) else {
+            throw NSError(
+                domain: "ShortcutCycleIntegration",
+                code: 9,
+                userInfo: [NSLocalizedDescriptionKey: "Expected integration fixture at \(validFixtureURL.path)."]
+            )
+        }
+
+        return RuntimeContext(
+            appURL: appURL,
+            validFixtureURL: validFixtureURL,
+            runRootURL: runRootURL,
+            appBundleIdentifier: appBundleIdentifier
+        )
+    }
+
+    private func loadContextFile() -> [String: String] {
+        guard let contents = try? String(contentsOf: Self.contextFileURL, encoding: .utf8) else {
+            return [:]
+        }
+
+        var values: [String: String] = [:]
+        for line in contents.split(whereSeparator: \.isNewline) {
+            guard let separatorIndex = line.firstIndex(of: "=") else { continue }
+            let key = String(line[..<separatorIndex])
+            let valueStart = line.index(after: separatorIndex)
+            let value = String(line[valueStart...])
+            values[key] = value
+        }
+        return values
+    }
+}

--- a/ShortcutCycle/scripts/integration_window_probe.swift
+++ b/ShortcutCycle/scripts/integration_window_probe.swift
@@ -1,0 +1,116 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+enum ProbeCommand: String {
+    case appPath = "app-path"
+    case describeRunning = "describe-running"
+    case pids
+    case running
+    case waitVisibleWindow = "wait-visible-window"
+}
+
+func writeError(_ message: String) {
+    if let data = (message + "\n").data(using: .utf8) {
+        FileHandle.standardError.write(data)
+    }
+}
+
+func runningApplications(bundleIdentifier: String) -> [NSRunningApplication] {
+    NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier)
+        .filter { !$0.isTerminated }
+}
+
+func describeRunningApplications(bundleIdentifier: String) -> [String] {
+    runningApplications(bundleIdentifier: bundleIdentifier).map { application in
+        let name = application.localizedName ?? bundleIdentifier
+        return "\(name) pid=\(application.processIdentifier) active=\(application.isActive) hidden=\(application.isHidden) finishedLaunching=\(application.isFinishedLaunching)"
+    }
+}
+
+func hasVisibleRegularWindow(bundleIdentifier: String) -> Bool {
+    let processIdentifiers = Set(runningApplications(bundleIdentifier: bundleIdentifier).map(\.processIdentifier))
+    guard !processIdentifiers.isEmpty else { return false }
+
+    guard let windows = CGWindowListCopyWindowInfo(
+        [.optionOnScreenOnly, .excludeDesktopElements],
+        kCGNullWindowID
+    ) as? [[String: Any]] else {
+        return false
+    }
+
+    return windows.contains { window in
+        guard let ownerPID = window[kCGWindowOwnerPID as String] as? Int32,
+              processIdentifiers.contains(ownerPID) else {
+            return false
+        }
+
+        let layer = (window[kCGWindowLayer as String] as? Int) ?? 0
+        guard layer == 0 else { return false }
+
+        let alpha = (window[kCGWindowAlpha as String] as? Double) ?? 1.0
+        guard alpha > 0.01 else { return false }
+
+        guard let bounds = window[kCGWindowBounds as String] as? [String: Any],
+              let width = bounds["Width"] as? Double,
+              let height = bounds["Height"] as? Double else {
+            return false
+        }
+
+        return width > 1.0 && height > 1.0
+    }
+}
+
+let arguments = CommandLine.arguments
+guard arguments.count >= 3,
+      let command = ProbeCommand(rawValue: arguments[1]) else {
+    writeError("Usage: integration_window_probe.swift <app-path|describe-running|pids|running|wait-visible-window> <bundle-id> [timeout-seconds]")
+    exit(64)
+}
+
+let bundleIdentifier = arguments[2]
+
+switch command {
+case .appPath:
+    guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) else {
+        exit(1)
+    }
+
+    print(url.path)
+    exit(0)
+case .describeRunning:
+    let descriptions = describeRunningApplications(bundleIdentifier: bundleIdentifier)
+    guard !descriptions.isEmpty else {
+        exit(1)
+    }
+
+    for description in descriptions {
+        print(description)
+    }
+    exit(0)
+case .pids:
+    let pids = runningApplications(bundleIdentifier: bundleIdentifier).map(\.processIdentifier)
+    guard !pids.isEmpty else {
+        exit(1)
+    }
+
+    for pid in pids {
+        print(pid)
+    }
+    exit(0)
+case .running:
+    exit(runningApplications(bundleIdentifier: bundleIdentifier).isEmpty ? 1 : 0)
+case .waitVisibleWindow:
+    let timeout = arguments.count >= 4 ? (Double(arguments[3]) ?? 15.0) : 15.0
+    let deadline = Date().addingTimeInterval(timeout)
+
+    while Date() < deadline {
+        if hasVisibleRegularWindow(bundleIdentifier: bundleIdentifier) {
+            exit(0)
+        }
+        Thread.sleep(forTimeInterval: 0.1)
+    }
+
+    writeError("Timed out waiting for a visible regular window for \(bundleIdentifier)")
+    exit(1)
+}

--- a/ShortcutCycle/scripts/run_integration_harness.sh
+++ b/ShortcutCycle/scripts/run_integration_harness.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PROJECT_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$PROJECT_ROOT/.." && pwd)
+
+PROJECT_FILE="ShortcutCycle.xcodeproj"
+SCHEME="ShortcutCycleIntegration"
+CONFIGURATION="Debug"
+APP_BUNDLE_ID="com.xcv58.ShortcutCycle.Integration"
+FIXTURE_PATH="$PROJECT_ROOT/ShortcutCycleIntegrationFixtures/IntegrationHUD.settings.json"
+WINDOW_PROBE="$SCRIPT_DIR/integration_window_probe.swift"
+
+CALCULATOR_BUNDLE_ID="com.apple.calculator"
+CHESS_BUNDLE_ID="com.apple.Chess"
+
+MAKE_VIDEO=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --video)
+            MAKE_VIDEO=1
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 64
+            ;;
+    esac
+    shift
+done
+
+RUN_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+RUN_ROOT="$REPO_ROOT/.artifacts/integration/$RUN_ID"
+XCODE_ROOT="$REPO_ROOT/.artifacts/xcode-integration"
+DERIVED_DATA="$XCODE_ROOT/DerivedData"
+CLONED_PACKAGES="$XCODE_ROOT/SourcePackages"
+MODULE_CACHE_ROOT="$XCODE_ROOT/ModuleCache"
+CLANG_MODULE_CACHE="$MODULE_CACHE_ROOT/clang"
+SWIFT_MODULE_CACHE="$MODULE_CACHE_ROOT/swift"
+CONTEXT_FILE="$XCODE_ROOT/integration-context.env"
+APP_PATH="$DERIVED_DATA/Build/Products/$CONFIGURATION/ShortcutCycle.app"
+
+LAUNCHED_SYSTEM_APPS=0
+LAUNCHED_APP_PIDS=()
+
+log() {
+    echo "[integration] $*"
+}
+
+fail() {
+    echo "[integration] $*" >&2
+    exit 1
+}
+
+run_window_probe() {
+    /usr/bin/env \
+        CLANG_MODULE_CACHE_PATH="$CLANG_MODULE_CACHE" \
+        SWIFT_MODULE_CACHE_PATH="$SWIFT_MODULE_CACHE" \
+        swift "$WINDOW_PROBE" "$@"
+}
+
+cleanup() {
+    if [ "$LAUNCHED_SYSTEM_APPS" -eq 1 ] && [ ${#LAUNCHED_APP_PIDS[@]} -gt 0 ]; then
+        kill "${LAUNCHED_APP_PIDS[@]}" >/dev/null 2>&1 || true
+    fi
+}
+
+trap cleanup EXIT
+
+app_is_running() {
+    local bundle_id="$1"
+
+    if run_window_probe running "$bundle_id" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    return 1
+}
+
+describe_running_app() {
+    local bundle_id="$1"
+    run_window_probe describe-running "$bundle_id" 2>/dev/null || true
+}
+
+append_launched_app_pids() {
+    local bundle_id="$1"
+    local pid
+
+    while IFS= read -r pid; do
+        [ -n "$pid" ] || continue
+        LAUNCHED_APP_PIDS+=("$pid")
+    done < <(run_window_probe pids "$bundle_id" 2>/dev/null || true)
+}
+
+launch_and_wait_for_window() {
+    local bundle_id="$1"
+
+    /usr/bin/open -b "$bundle_id" >/dev/null 2>&1 || {
+        fail "Required app with bundle ID $bundle_id could not be launched."
+    }
+
+    run_window_probe wait-visible-window "$bundle_id" 15 >/dev/null || {
+        fail "Timed out waiting for a visible regular window for $bundle_id."
+    }
+
+    append_launched_app_pids "$bundle_id"
+}
+
+maybe_make_video() {
+    local frames_dir="$RUN_ROOT/happy-path/frames"
+    local output_path="$RUN_ROOT/happy-path/playback.mp4"
+
+    if [ "$MAKE_VIDEO" -ne 1 ]; then
+        return
+    fi
+
+    if ! command -v ffmpeg >/dev/null 2>&1; then
+        log "Skipping video generation because ffmpeg is not available."
+        return
+    fi
+
+    if ! find "$frames_dir" -name '*.png' -print -quit 2>/dev/null | grep -q .; then
+        log "Skipping video generation because no PNG frames were captured."
+        return
+    fi
+
+    ffmpeg -y \
+        -framerate 1 \
+        -pattern_type glob \
+        -i "$frames_dir/*.png" \
+        -pix_fmt yuv420p \
+        "$output_path" >/dev/null 2>&1 || {
+        log "ffmpeg was available but failed to generate $output_path."
+        return
+    }
+
+    log "Generated playback video at $output_path"
+}
+
+mkdir -p "$RUN_ROOT" "$DERIVED_DATA" "$CLONED_PACKAGES" "$CLANG_MODULE_CACHE" "$SWIFT_MODULE_CACHE"
+
+[ -f "$FIXTURE_PATH" ] || fail "Fixture not found at $FIXTURE_PATH"
+[ -f "$WINDOW_PROBE" ] || fail "Window probe helper not found at $WINDOW_PROBE"
+
+running_apps=()
+
+if app_is_running "$CALCULATOR_BUNDLE_ID"; then
+    running_apps+=("Calculator: $(describe_running_app "$CALCULATOR_BUNDLE_ID" | tr '\n' '; ' | sed 's/; $//')")
+fi
+
+if app_is_running "$CHESS_BUNDLE_ID"; then
+    running_apps+=("Chess: $(describe_running_app "$CHESS_BUNDLE_ID" | tr '\n' '; ' | sed 's/; $//')")
+fi
+
+if [ ${#running_apps[@]} -gt 0 ]; then
+    fail "Preflight failed because these apps still have a running process: ${running_apps[*]}. Closing the window is not always enough on macOS; fully quit the app and rerun."
+fi
+
+log "Launching Calculator and Chess for the happy-path run."
+LAUNCHED_SYSTEM_APPS=1
+launch_and_wait_for_window "$CALCULATOR_BUNDLE_ID"
+launch_and_wait_for_window "$CHESS_BUNDLE_ID"
+/usr/bin/osascript -e 'tell application id "com.apple.finder" to activate' >/dev/null 2>&1 || true
+
+export SHORTCUTCYCLE_INTEGRATION_APP_PATH="$APP_PATH"
+export SHORTCUTCYCLE_INTEGRATION_VALID_FIXTURE_PATH="$FIXTURE_PATH"
+export SHORTCUTCYCLE_INTEGRATION_RUN_ROOT="$RUN_ROOT"
+export SHORTCUTCYCLE_INTEGRATION_APP_BUNDLE_ID="$APP_BUNDLE_ID"
+
+printf '%s\n' \
+    "SHORTCUTCYCLE_INTEGRATION_APP_PATH=$APP_PATH" \
+    "SHORTCUTCYCLE_INTEGRATION_VALID_FIXTURE_PATH=$FIXTURE_PATH" \
+    "SHORTCUTCYCLE_INTEGRATION_RUN_ROOT=$RUN_ROOT" \
+    "SHORTCUTCYCLE_INTEGRATION_APP_BUNDLE_ID=$APP_BUNDLE_ID" \
+    > "$CONTEXT_FILE"
+
+log "Artifacts will be written to $RUN_ROOT"
+
+(
+    cd "$PROJECT_ROOT"
+    xcodebuild test \
+        -project "$PROJECT_FILE" \
+        -scheme "$SCHEME" \
+        -configuration "$CONFIGURATION" \
+        -destination "platform=macOS" \
+        -derivedDataPath "$DERIVED_DATA" \
+        -clonedSourcePackagesDirPath "$CLONED_PACKAGES" \
+        -parallel-testing-enabled NO \
+        SHORTCUTCYCLE_APP_BUNDLE_IDENTIFIER="$APP_BUNDLE_ID"
+)
+
+maybe_make_video
+
+log "Integration harness finished successfully."
+log "Artifacts: $RUN_ROOT"


### PR DESCRIPTION
## What changed

- added a local-only `ShortcutCycleIntegrationTests` harness for real app switching on macOS
- added a hidden app-side integration runtime that imports a fixture, listens for harness commands, and emits `fixtureLoaded`, `hudPresented`, `switchFinalized`, and `error` events
- added a checked-in HUD fixture, a local runner script, screenshot capture support, and optional playback video generation from captured PNG frames
- updated the harness screenshot selection so captures follow the relevant visible window first, with fallback display selection when that lookup fails

## Why this changed

We needed a real macOS integration path that exercises the production switching flow against actual system apps instead of only unit-level abstractions. This gives us deterministic fixture setup, real frontmost-app assertions, and visual artifacts developers can inspect locally.

## Developer impact

- developers can run `bash scripts/run_integration_harness.sh` locally to build the isolated integration app, launch Calculator and Chess, execute the three-cycle scenario, and save screenshots under `.artifacts/integration/<run-id>`
- `--video` can assemble a playback MP4 from the captured frames when `ffmpeg` is available
- the app uses an isolated bundle identifier for the integration run so defaults and sandbox state stay separate from the normal dev app

## Root cause addressed

The earlier harness work had two main problems:

1. the app and test process needed a reliable private command/event channel and deterministic fixture bootstrap path inside the sandboxed integration container
2. screenshot/video capture needed to stop blindly recording the wrong display when multiple monitors were connected

This PR adds the sandbox-aware harness plumbing and makes frame capture follow the relevant visible window before falling back to display preference heuristics.

## Validation

- passed: `xcodebuild build-for-testing -project ShortcutCycle/ShortcutCycle.xcodeproj -scheme ShortcutCycleIntegration -configuration Debug -destination 'platform=macOS' -derivedDataPath .artifacts/xcode-integration/DerivedData -clonedSourcePackagesDirPath .artifacts/xcode-integration/SourcePackages SHORTCUTCYCLE_APP_BUNDLE_IDENTIFIER=com.xcv58.ShortcutCycle.Integration`
- exercised repeatedly: `bash ShortcutCycle/scripts/run_integration_harness.sh`

## Known issue

The real happy-path integration run still has an intermittent frontmost-app flake during the final assertion phase. The draft is intentional so we can review the harness structure and current behavior while that macOS focus race is still being tightened up.