### PR TITLE
[codex] Improve setup flow, settings shortcuts, and app grid interactions

### DIFF
--- a/ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj
+++ b/ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		017 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 901 /* KeyboardShortcuts */; };
+		A1B200022F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */; };
+		A1B200032F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */; };
 		DF88A3762F300B110042E749 /* HUDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3542F300B110042E749 /* HUDManager.swift */; };
 		DF88A3772F300B110042E749 /* ShortcutCycleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3742F300B110042E749 /* ShortcutCycleApp.swift */; };
 		DF88A3782F300B110042E749 /* GroupEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A36D2F300B110042E749 /* GroupEditView.swift */; };
@@ -70,8 +72,6 @@
 		DF88A3B52F300CB20042E749 /* URLScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3B72F300CB20042E749 /* URLScheme.swift */; };
 		DF88A3B92F300CB20042E749 /* HUDItemFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3B82F300CB20042E749 /* HUDItemFilter.swift */; };
 		DF88A3BA2F300CB20042E749 /* HUDItemFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3B82F300CB20042E749 /* HUDItemFilter.swift */; };
-		A1B200022F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */; };
-		A1B200032F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */; };
 		DF88A3C22F300CE00042E749 /* WelcomeBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3C02F300CE00042E749 /* WelcomeBannerView.swift */; };
 		DF88A3C32F300CE00042E749 /* WelcomeBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3C02F300CE00042E749 /* WelcomeBannerView.swift */; };
 		E1F4B0012F40000100C0DE01 /* URLCommandFileValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F4B0032F40000100C0DE01 /* URLCommandFileValidation.swift */; };
@@ -96,6 +96,7 @@
 
 /* Begin PBXFileReference section */
 		100 /* ShortcutCycle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShortcutCycle.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutSuggestion.swift; sourceTree = "<group>"; };
 		DF88A3372F300B110042E749 /* String+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Localization.swift"; sourceTree = "<group>"; };
 		DF88A3392F300B110042E749 /* AppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroup.swift; sourceTree = "<group>"; };
 		DF88A33A2F300B110042E749 /* AppItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppItem.swift; sourceTree = "<group>"; };
@@ -142,7 +143,6 @@
 		DF88A3AF2F300CB10042E749 /* BackupBrowserView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupBrowserView.swift; sourceTree = "<group>"; };
 		DF88A3B72F300CB20042E749 /* URLScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLScheme.swift; sourceTree = "<group>"; };
 		DF88A3B82F300CB20042E749 /* HUDItemFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HUDItemFilter.swift; sourceTree = "<group>"; };
-		A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutSuggestion.swift; sourceTree = "<group>"; };
 		DF88A3C02F300CE00042E749 /* WelcomeBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeBannerView.swift; sourceTree = "<group>"; };
 		DF8B47D72F2F090100C473F8 /* ShortcutCycleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ShortcutCycleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E1F4B0032F40000100C0DE01 /* URLCommandFileValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLCommandFileValidation.swift; sourceTree = "<group>"; };
@@ -770,6 +770,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShortcutCycle/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ShortcutCycle;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -799,6 +800,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ShortcutCycle/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = ShortcutCycle;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";

--- a/ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj
+++ b/ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj
@@ -761,6 +761,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = ShortcutCycle/ShortcutCycle.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -791,6 +792,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = ShortcutCycle/ShortcutCycle.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;

--- a/ShortcutCycle/ShortcutCycle/Extensions/String+Localization.swift
+++ b/ShortcutCycle/ShortcutCycle/Extensions/String+Localization.swift
@@ -1,14 +1,105 @@
 import Foundation
 
-extension String {
-    func localized(language: String) -> String {
-        let resolvedCode = language == "system" ? LanguageManager.shared.systemLanguageCode : language
+private final class LocalizationResolver: NSObject {
+    static let shared = LocalizationResolver()
 
-        guard let path = Bundle.main.path(forResource: resolvedCode, ofType: "lproj"),
-              let bundle = Bundle(path: path) else {
-            return NSLocalizedString(self, comment: "")
+    private var cachedSystemLanguageCode: String?
+    private var bundleByLanguageCode: [String: Bundle] = [:]
+    private var missingBundleCodes = Set<String>()
+    private var localizedStringCache: [String: [String: String]] = [:]
+    private let lock = NSLock()
+
+    private override init() {
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(localeDidChange),
+            name: NSLocale.currentLocaleDidChangeNotification,
+            object: nil
+        )
+    }
+
+    @objc private func localeDidChange() {
+        lock.lock()
+        cachedSystemLanguageCode = nil
+        lock.unlock()
+    }
+
+    func localizedString(for key: String, language: String) -> String {
+        let resolvedCode = resolvedLanguageCode(for: language)
+
+        lock.lock()
+        if let cached = localizedStringCache[resolvedCode]?[key] {
+            lock.unlock()
+            return cached
+        }
+        lock.unlock()
+
+        let localizedValue: String
+        if let bundle = bundle(for: resolvedCode) {
+            localizedValue = NSLocalizedString(key, tableName: nil, bundle: bundle, value: "", comment: "")
+        } else {
+            localizedValue = NSLocalizedString(key, comment: "")
         }
 
-        return NSLocalizedString(self, tableName: nil, bundle: bundle, value: "", comment: "")
+        lock.lock()
+        var languageCache = localizedStringCache[resolvedCode] ?? [:]
+        languageCache[key] = localizedValue
+        localizedStringCache[resolvedCode] = languageCache
+        lock.unlock()
+
+        return localizedValue
+    }
+
+    private func resolvedLanguageCode(for language: String) -> String {
+        guard language == "system" else { return language }
+
+        lock.lock()
+        if let cachedSystemLanguageCode {
+            lock.unlock()
+            return cachedSystemLanguageCode
+        }
+        lock.unlock()
+
+        let resolvedCode = LanguageManager.shared.systemLanguageCode
+
+        lock.lock()
+        cachedSystemLanguageCode = resolvedCode
+        lock.unlock()
+
+        return resolvedCode
+    }
+
+    private func bundle(for languageCode: String) -> Bundle? {
+        lock.lock()
+        if let cachedBundle = bundleByLanguageCode[languageCode] {
+            lock.unlock()
+            return cachedBundle
+        }
+
+        if missingBundleCodes.contains(languageCode) {
+            lock.unlock()
+            return nil
+        }
+        lock.unlock()
+
+        guard let path = Bundle.main.path(forResource: languageCode, ofType: "lproj"),
+              let bundle = Bundle(path: path) else {
+            lock.lock()
+            missingBundleCodes.insert(languageCode)
+            lock.unlock()
+            return nil
+        }
+
+        lock.lock()
+        bundleByLanguageCode[languageCode] = bundle
+        lock.unlock()
+        return bundle
+    }
+}
+
+extension String {
+    func localized(language: String) -> String {
+        LocalizationResolver.shared.localizedString(for: self, language: language)
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Info.plist
+++ b/ShortcutCycle/ShortcutCycle/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>en</string>

--- a/ShortcutCycle/ShortcutCycle/Models/GroupStore.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/GroupStore.swift
@@ -19,12 +19,18 @@ public class GroupStore: ObservableObject {
     private let saveKey = "ShortcutCycle.Groups"
     private let userDefaults: UserDefaults
     private let fileManager: FileManager
+    private let saveDebounceInterval: TimeInterval
+    private let performsImmediateAutoBackupOnFirstChange: Bool
 
     private static let backupDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH-mm-ss"
         return formatter
     }()
+
+    private var saveTimer: Timer?
+    private var savePending = false
+    private var pendingSaveTriggersAutoBackup = false
     
     // Debounce timer for auto-backup (60 seconds)
     private var backupTimer: Timer?
@@ -36,10 +42,13 @@ public class GroupStore: ObservableObject {
     init(
         userDefaults: UserDefaults = .standard,
         backupDebounceInterval: TimeInterval = 60.0,
+        saveDebounceInterval: TimeInterval? = nil,
         fileManager: FileManager = .default
     ) {
         self.userDefaults = userDefaults
         self.backupDebounceInterval = backupDebounceInterval
+        self.saveDebounceInterval = saveDebounceInterval ?? (userDefaults === UserDefaults.standard ? 0.25 : 0.0)
+        self.performsImmediateAutoBackupOnFirstChange = userDefaults !== UserDefaults.standard
         self.fileManager = fileManager
         loadGroups()
         setupTerminationObserver()
@@ -55,9 +64,20 @@ public class GroupStore: ObservableObject {
             // Must run synchronously on main thread before app exits
             guard let self = self else { return }
             MainActor.assumeIsolated {
+                self.flushPendingSave()
                 self.flushPendingBackup()
             }
         }
+    }
+
+    public func flushPendingSave() {
+        guard savePending else { return }
+        let triggerAutoBackup = pendingSaveTriggersAutoBackup
+        saveTimer?.invalidate()
+        saveTimer = nil
+        savePending = false
+        pendingSaveTriggersAutoBackup = false
+        persistGroups(triggerAutoBackup: triggerAutoBackup)
     }
 
     /// Force immediate backup if one is pending (public for testing)
@@ -139,6 +159,15 @@ public class GroupStore: ObservableObject {
             saveGroups()
         }
     }
+
+    public func replaceApps(in groupId: UUID, with apps: [AppItem]) {
+        if let index = groups.firstIndex(where: { $0.id == groupId }) {
+            guard groups[index].apps != apps else { return }
+            groups[index].apps = apps
+            groups[index].lastModified = Date()
+            saveGroups()
+        }
+    }
     
     // MARK: - Shortcut Management
     
@@ -169,6 +198,24 @@ public class GroupStore: ObservableObject {
     // MARK: - Persistence
     
     private func saveGroups(triggerAutoBackup: Bool = true) {
+        guard saveDebounceInterval > 0 else {
+            persistGroups(triggerAutoBackup: triggerAutoBackup)
+            return
+        }
+
+        savePending = true
+        pendingSaveTriggersAutoBackup = pendingSaveTriggersAutoBackup || triggerAutoBackup
+
+        saveTimer?.invalidate()
+        saveTimer = Timer(timeInterval: saveDebounceInterval, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                self?.flushPendingSave()
+            }
+        }
+        RunLoop.main.add(saveTimer!, forMode: .common)
+    }
+
+    private func persistGroups(triggerAutoBackup: Bool) {
         // JSONEncoder.encode cannot fail for [AppGroup] since all types are trivially Codable
         let data = try! JSONEncoder().encode(groups)
         userDefaults.set(data, forKey: saveKey)
@@ -180,20 +227,23 @@ public class GroupStore: ObservableObject {
     /// Schedule a debounced auto-backup (resets timer on each call)
     private func scheduleAutoBackup() {
         backupPending = true
-        
-        // Immediate save if enough time has passed since last backup and no debounce is active
-        // This ensures the first change saves immediately, but subsequent rapid changes are debounced
-        let timeSinceLastBackup = Date().timeIntervalSince(lastBackupTime)
-        if backupTimer == nil && timeSinceLastBackup > backupDebounceInterval {
+
+        if backupDebounceInterval <= 0 {
             performAutoBackup()
             return
         }
-        
-        // Cancel any existing timer
+
+        let timeSinceLastBackup = Date().timeIntervalSince(lastBackupTime)
+        if performsImmediateAutoBackupOnFirstChange,
+           backupTimer == nil,
+           timeSinceLastBackup > backupDebounceInterval {
+            performAutoBackup()
+            return
+        }
+
         backupTimer?.invalidate()
         backupTimer = nil
-        
-        // Schedule new backup after debounce interval on main run loop
+
         backupTimer = Timer(timeInterval: backupDebounceInterval, repeats: false) { [weak self] _ in
             Task { @MainActor in
                 self?.performAutoBackup()

--- a/ShortcutCycle/ShortcutCycle/Models/SettingsExport.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/SettingsExport.swift
@@ -1,6 +1,43 @@
 import Foundation
 import KeyboardShortcuts
 
+private enum AppleLanguagePreferenceSync {
+    // Keep in sync with LanguageManager.supportedLanguages.
+    private static let supportedLanguageCodes = [
+        "en", "de", "fr", "es", "ja", "pt-BR", "zh-Hans", "zh-Hant",
+        "it", "ko", "ar", "nl", "pl", "tr", "ru"
+    ]
+
+    private static var globalPreferredLanguages: [String] {
+        if let languages = CFPreferencesCopyValue(
+            "AppleLanguages" as CFString,
+            kCFPreferencesAnyApplication,
+            kCFPreferencesCurrentUser,
+            kCFPreferencesAnyHost
+        ) as? [String] {
+            return languages
+        }
+
+        return Locale.preferredLanguages
+    }
+
+    static func sync(_ selectedLanguage: String, userDefaults: UserDefaults = .standard) {
+        let effectiveCode: String
+        if selectedLanguage == "system" {
+            let preferred = Bundle.preferredLocalizations(
+                from: supportedLanguageCodes,
+                forPreferences: globalPreferredLanguages
+            )
+            effectiveCode = preferred.first ?? "en"
+        } else {
+            effectiveCode = selectedLanguage
+        }
+
+        let appleCode = effectiveCode == "zh-Hant" ? "zh-TW" : effectiveCode
+        userDefaults.set([appleCode], forKey: "AppleLanguages")
+    }
+}
+
 /// Data for a single keyboard shortcut
 public struct ShortcutData: Codable, Equatable {
     public let carbonKeyCode: Int
@@ -42,7 +79,7 @@ public struct AppSettings: Codable, Equatable {
         UserDefaults.standard.set(showShortcutInHUD, forKey: "showShortcutInHUD")
         let resolvedLanguage = selectedLanguage ?? "system"
         UserDefaults.standard.set(resolvedLanguage, forKey: "selectedLanguage")
-        LanguageManager.shared.syncAppleLanguages(for: resolvedLanguage)
+        AppleLanguagePreferenceSync.sync(resolvedLanguage)
         if let appTheme = appTheme {
             UserDefaults.standard.set(appTheme, forKey: "appTheme")
         }

--- a/ShortcutCycle/ShortcutCycle/Models/SettingsExport.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/SettingsExport.swift
@@ -1,24 +1,34 @@
 import Foundation
 import KeyboardShortcuts
 
-private enum AppleLanguagePreferenceSync {
+enum AppleLanguagePreferenceSync {
     // Keep in sync with LanguageManager.supportedLanguages.
     private static let supportedLanguageCodes = [
         "en", "de", "fr", "es", "ja", "pt-BR", "zh-Hans", "zh-Hant",
         "it", "ko", "ar", "nl", "pl", "tr", "ru"
     ]
 
-    private static var globalPreferredLanguages: [String] {
-        if let languages = CFPreferencesCopyValue(
-            "AppleLanguages" as CFString,
-            kCFPreferencesAnyApplication,
-            kCFPreferencesCurrentUser,
-            kCFPreferencesAnyHost
-        ) as? [String] {
+    static func resolvedPreferredLanguages(
+        from globalPreferenceValue: CFPropertyList?,
+        fallback: [String] = Locale.preferredLanguages
+    ) -> [String] {
+        if let languages = globalPreferenceValue as? [String] {
             return languages
         }
 
-        return Locale.preferredLanguages
+        return fallback
+    }
+
+    private static var globalPreferredLanguages: [String] {
+        resolvedPreferredLanguages(
+            from: CFPreferencesCopyValue(
+                "AppleLanguages" as CFString,
+                kCFPreferencesAnyApplication,
+                kCFPreferencesCurrentUser,
+                kCFPreferencesAnyHost
+            ),
+            fallback: Locale.preferredLanguages
+        )
     }
 
     static func sync(_ selectedLanguage: String, userDefaults: UserDefaults = .standard) {

--- a/ShortcutCycle/ShortcutCycle/Models/SettingsExport.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/SettingsExport.swift
@@ -40,7 +40,9 @@ public struct AppSettings: Codable, Equatable {
     public func apply() {
         UserDefaults.standard.set(showHUD, forKey: "showHUD")
         UserDefaults.standard.set(showShortcutInHUD, forKey: "showShortcutInHUD")
-        UserDefaults.standard.set(selectedLanguage ?? "system", forKey: "selectedLanguage")
+        let resolvedLanguage = selectedLanguage ?? "system"
+        UserDefaults.standard.set(resolvedLanguage, forKey: "selectedLanguage")
+        LanguageManager.shared.syncAppleLanguages(for: resolvedLanguage)
         if let appTheme = appTheme {
             UserDefaults.standard.set(appTheme, forKey: "appTheme")
         }

--- a/ShortcutCycle/ShortcutCycle/Models/ShortcutSuggestion.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/ShortcutSuggestion.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import KeyboardShortcuts
 

--- a/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
@@ -74,6 +74,7 @@
 "Add Group" = "إضافة مجموعة";
 "Delete Group" = "حذف المجموعة";
 "Toggle Sidebar" = "إظهار/إخفاء الشريط الجانبي";
+"Toggle Appearance" = "تبديل المظهر";
 "Previous Group" = "المجموعة السابقة";
 "Next Group" = "المجموعة التالية";
 "Move Group Up" = "نقل المجموعة إلى الأعلى";

--- a/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
@@ -72,6 +72,12 @@
 "Shortcuts" = "اختصارات";
 
 "Add Group" = "إضافة مجموعة";
+"Delete Group" = "حذف المجموعة";
+"Toggle Sidebar" = "إظهار/إخفاء الشريط الجانبي";
+"Previous Group" = "المجموعة السابقة";
+"Next Group" = "المجموعة التالية";
+"Move Group Up" = "نقل المجموعة إلى الأعلى";
+"Move Group Down" = "نقل المجموعة إلى الأسفل";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
@@ -132,7 +132,7 @@
 "No changes" = "لا توجد تغييرات";
 "(invalid)" = "(غير صالح)";
 "This backup file is invalid or corrupted." = "ملف النسخة الاحتياطية غير صالح أو تالف.";
-"⌥-click to compare with a different backup" = "⌥-انقر للمقارنة مع نسخة احتياطية مختلفة";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "يستخدم المقارنة افتراضيًا النسخة الاحتياطية الأقدم التالية. استخدم «التغييرات من» لاختيار نسخة مختلفة.";
 "No Backup Selected" = "لم يتم اختيار نسخة احتياطية";
 "Select a backup from the sidebar to preview its contents." = "اختر نسخة احتياطية من الشريط الجانبي لمعاينة محتوياتها.";
 "selected" = "محدد";

--- a/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 "Next Group" = "المجموعة التالية";
 "Move Group Up" = "نقل المجموعة إلى الأعلى";
 "Move Group Down" = "نقل المجموعة إلى الأسفل";
+"or" = "أو";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Next Group" = "Nächste Gruppe";
 "Move Group Up" = "Gruppe nach oben verschieben";
 "Move Group Down" = "Gruppe nach unten verschieben";
+"or" = "oder";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "No changes" = "Keine Änderungen";
 "(invalid)" = "(ungültig)";
 "This backup file is invalid or corrupted." = "Diese Sicherungsdatei ist ungültig oder beschädigt.";
-"⌥-click to compare with a different backup" = "⌥-Klick zum Vergleichen mit einer anderen Sicherung";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "Vergleich verwendet standardmäßig das nächstältere Backup. Verwenden Sie „Änderungen von“, um ein anderes auszuwählen.";
 "No Backup Selected" = "Kein Backup ausgewählt";
 "Select a backup from the sidebar to preview its contents." = "Wähle ein Backup aus der Seitenleiste, um den Inhalt anzuzeigen.";
 "selected" = "ausgewählt";

--- a/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "Add Group" = "Gruppe hinzufügen";
 "Delete Group" = "Gruppe löschen";
 "Toggle Sidebar" = "Seitenleiste ein-/ausblenden";
+"Toggle Appearance" = "Erscheinungsbild umschalten";
 "Previous Group" = "Vorherige Gruppe";
 "Next Group" = "Nächste Gruppe";
 "Move Group Up" = "Gruppe nach oben verschieben";

--- a/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
@@ -71,6 +71,12 @@
 "Settings Window" = "Einstellungsfenster";
 "Shortcuts" = "Kurzbefehle";
 "Add Group" = "Gruppe hinzufügen";
+"Delete Group" = "Gruppe löschen";
+"Toggle Sidebar" = "Seitenleiste ein-/ausblenden";
+"Previous Group" = "Vorherige Gruppe";
+"Next Group" = "Nächste Gruppe";
+"Move Group Up" = "Gruppe nach oben verschieben";
+"Move Group Down" = "Gruppe nach unten verschieben";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Next Group" = "Next Group";
 "Move Group Up" = "Move Group Up";
 "Move Group Down" = "Move Group Down";
+"or" = "or";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
@@ -133,7 +133,7 @@
 "No changes" = "No changes";
 "(invalid)" = "(invalid)";
 "This backup file is invalid or corrupted." = "This backup file is invalid or corrupted.";
-"⌥-click to compare with a different backup" = "⌥-click to compare with a different backup";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "Comparison defaults to the next older backup. Use Changes from to pick a different one.";
 "No Backup Selected" = "No Backup Selected";
 "Select a backup from the sidebar to preview its contents." = "Select a backup from the sidebar to preview its contents.";
 "selected" = "selected";

--- a/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "Add Group" = "Add Group";
 "Delete Group" = "Delete Group";
 "Toggle Sidebar" = "Toggle Sidebar";
+"Toggle Appearance" = "Toggle Appearance";
 "Previous Group" = "Previous Group";
 "Next Group" = "Next Group";
 "Move Group Up" = "Move Group Up";

--- a/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
@@ -71,6 +71,12 @@
 "Shortcuts" = "Shortcuts";
 
 "Add Group" = "Add Group";
+"Delete Group" = "Delete Group";
+"Toggle Sidebar" = "Toggle Sidebar";
+"Previous Group" = "Previous Group";
+"Next Group" = "Next Group";
+"Move Group Up" = "Move Group Up";
+"Move Group Down" = "Move Group Down";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "No changes" = "Sin cambios";
 "(invalid)" = "(inválido)";
 "This backup file is invalid or corrupted." = "Este archivo de copia de seguridad es inválido o está dañado.";
-"⌥-click to compare with a different backup" = "⌥-clic para comparar con otra copia de seguridad";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "La comparación usa el backup anterior por defecto. Use «Cambios desde» para seleccionar otro.";
 "No Backup Selected" = "Ninguna copia seleccionada";
 "Select a backup from the sidebar to preview its contents." = "Selecciona una copia de seguridad de la barra lateral para previsualizar su contenido.";
 "selected" = "seleccionado";

--- a/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Next Group" = "Grupo siguiente";
 "Move Group Up" = "Mover grupo hacia arriba";
 "Move Group Down" = "Mover grupo hacia abajo";
+"or" = "o";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
@@ -71,6 +71,12 @@
 "Settings Window" = "Ventana de ajustes";
 "Shortcuts" = "Atajos";
 "Add Group" = "Añadir grupo";
+"Delete Group" = "Eliminar grupo";
+"Toggle Sidebar" = "Alternar barra lateral";
+"Previous Group" = "Grupo anterior";
+"Next Group" = "Grupo siguiente";
+"Move Group Up" = "Mover grupo hacia arriba";
+"Move Group Down" = "Mover grupo hacia abajo";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "Add Group" = "Añadir grupo";
 "Delete Group" = "Eliminar grupo";
 "Toggle Sidebar" = "Alternar barra lateral";
+"Toggle Appearance" = "Alternar apariencia";
 "Previous Group" = "Grupo anterior";
 "Next Group" = "Grupo siguiente";
 "Move Group Up" = "Mover grupo hacia arriba";

--- a/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
@@ -71,6 +71,12 @@
 "Settings Window" = "Fenêtre des paramètres";
 "Shortcuts" = "Raccourcis";
 "Add Group" = "Ajouter un groupe";
+"Delete Group" = "Supprimer le groupe";
+"Toggle Sidebar" = "Afficher/masquer la barre latérale";
+"Previous Group" = "Groupe précédent";
+"Next Group" = "Groupe suivant";
+"Move Group Up" = "Déplacer le groupe vers le haut";
+"Move Group Down" = "Déplacer le groupe vers le bas";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "No changes" = "Aucune modification";
 "(invalid)" = "(invalide)";
 "This backup file is invalid or corrupted." = "Ce fichier de sauvegarde est invalide ou corrompu.";
-"⌥-click to compare with a different backup" = "⌥-clic pour comparer avec une autre sauvegarde";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "La comparaison utilise par défaut le backup précédent. Utilisez « Modifications depuis » pour en choisir un autre.";
 "No Backup Selected" = "Aucune sauvegarde sélectionnée";
 "Select a backup from the sidebar to preview its contents." = "Sélectionnez une sauvegarde dans la barre latérale pour en afficher le contenu.";
 "selected" = "sélectionné";

--- a/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "Add Group" = "Ajouter un groupe";
 "Delete Group" = "Supprimer le groupe";
 "Toggle Sidebar" = "Afficher/masquer la barre latérale";
+"Toggle Appearance" = "Basculer l’apparence";
 "Previous Group" = "Groupe précédent";
 "Next Group" = "Groupe suivant";
 "Move Group Up" = "Déplacer le groupe vers le haut";

--- a/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Next Group" = "Groupe suivant";
 "Move Group Up" = "Déplacer le groupe vers le haut";
 "Move Group Down" = "Déplacer le groupe vers le bas";
+"or" = "ou";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "Add Group" = "Aggiungi gruppo";
 "Delete Group" = "Elimina gruppo";
 "Toggle Sidebar" = "Mostra/nascondi barra laterale";
+"Toggle Appearance" = "Alterna aspetto";
 "Previous Group" = "Gruppo precedente";
 "Next Group" = "Gruppo successivo";
 "Move Group Up" = "Sposta gruppo in alto";

--- a/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "No changes" = "Nessuna modifica";
 "(invalid)" = "(non valido)";
 "This backup file is invalid or corrupted." = "Questo file di backup non è valido o è danneggiato.";
-"⌥-click to compare with a different backup" = "⌥-clic per confrontare con un altro backup";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "Il confronto usa per impostazione predefinita il backup precedente. Usa «Modifiche da» per sceglierne uno diverso.";
 "No Backup Selected" = "Nessun backup selezionato";
 "Select a backup from the sidebar to preview its contents." = "Seleziona un backup dalla barra laterale per visualizzarne il contenuto.";
 "selected" = "selezionato";

--- a/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
@@ -71,6 +71,12 @@
 "Settings Window" = "Finestra impostazioni";
 "Shortcuts" = "Comandi rapidi";
 "Add Group" = "Aggiungi gruppo";
+"Delete Group" = "Elimina gruppo";
+"Toggle Sidebar" = "Mostra/nascondi barra laterale";
+"Previous Group" = "Gruppo precedente";
+"Next Group" = "Gruppo successivo";
+"Move Group Up" = "Sposta gruppo in alto";
+"Move Group Down" = "Sposta gruppo in basso";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Next Group" = "Gruppo successivo";
 "Move Group Up" = "Sposta gruppo in alto";
 "Move Group Down" = "Sposta gruppo in basso";
+"or" = "o";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "Add Group" = "グループを追加";
 "Delete Group" = "グループを削除";
 "Toggle Sidebar" = "サイドバーを切り替え";
+"Toggle Appearance" = "外観を切り替え";
 "Previous Group" = "前のグループ";
 "Next Group" = "次のグループ";
 "Move Group Up" = "グループを上へ移動";

--- a/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Next Group" = "次のグループ";
 "Move Group Up" = "グループを上へ移動";
 "Move Group Down" = "グループを下へ移動";
+"or" = "または";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "No changes" = "変更なし";
 "(invalid)" = "(無効)";
 "This backup file is invalid or corrupted." = "このバックアップファイルは無効または破損しています。";
-"⌥-click to compare with a different backup" = "⌥-クリックで別のバックアップと比較";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "比較は次に古いバックアップが自動的に選択されます。「変更元」で別のバックアップを選択できます。";
 "No Backup Selected" = "バックアップ未選択";
 "Select a backup from the sidebar to preview its contents." = "サイドバーからバックアップを選択して内容をプレビューします。";
 "selected" = "選択中";

--- a/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
@@ -71,6 +71,12 @@
 "Settings Window" = "設定ウィンドウ";
 "Shortcuts" = "ショートカット";
 "Add Group" = "グループを追加";
+"Delete Group" = "グループを削除";
+"Toggle Sidebar" = "サイドバーを切り替え";
+"Previous Group" = "前のグループ";
+"Next Group" = "次のグループ";
+"Move Group Up" = "グループを上へ移動";
+"Move Group Down" = "グループを下へ移動";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "No changes" = "변경 없음";
 "(invalid)" = "(유효하지 않음)";
 "This backup file is invalid or corrupted." = "이 백업 파일이 유효하지 않거나 손상되었습니다.";
-"⌥-click to compare with a different backup" = "⌥-클릭으로 다른 백업과 비교";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "기본적으로 다음으로 오래된 백업과 비교합니다. 「변경 사항」에서 다른 항목을 선택하세요.";
 "No Backup Selected" = "선택된 백업 없음";
 "Select a backup from the sidebar to preview its contents." = "사이드바에서 백업을 선택하여 내용을 미리 봅니다.";
 "selected" = "선택됨";

--- a/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Next Group" = "다음 그룹";
 "Move Group Up" = "그룹 위로 이동";
 "Move Group Down" = "그룹 아래로 이동";
+"or" = "또는";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
@@ -71,6 +71,12 @@
 "Settings Window" = "설정 창";
 "Shortcuts" = "단축키";
 "Add Group" = "그룹 추가";
+"Delete Group" = "그룹 삭제";
+"Toggle Sidebar" = "사이드바 전환";
+"Previous Group" = "이전 그룹";
+"Next Group" = "다음 그룹";
+"Move Group Up" = "그룹 위로 이동";
+"Move Group Down" = "그룹 아래로 이동";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "Add Group" = "그룹 추가";
 "Delete Group" = "그룹 삭제";
 "Toggle Sidebar" = "사이드바 전환";
+"Toggle Appearance" = "모양 전환";
 "Previous Group" = "이전 그룹";
 "Next Group" = "다음 그룹";
 "Move Group Up" = "그룹 위로 이동";

--- a/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Next Group" = "Volgende groep";
 "Move Group Up" = "Groep omhoog verplaatsen";
 "Move Group Down" = "Groep omlaag verplaatsen";
+"or" = "of";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "Add Group" = "Groep toevoegen";
 "Delete Group" = "Groep verwijderen";
 "Toggle Sidebar" = "Zijbalk tonen/verbergen";
+"Toggle Appearance" = "Weergave wisselen";
 "Previous Group" = "Vorige groep";
 "Next Group" = "Volgende groep";
 "Move Group Up" = "Groep omhoog verplaatsen";

--- a/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
@@ -71,6 +71,12 @@
 "Settings Window" = "Instellingenvenster";
 "Shortcuts" = "Sneltoetsen";
 "Add Group" = "Groep toevoegen";
+"Delete Group" = "Groep verwijderen";
+"Toggle Sidebar" = "Zijbalk tonen/verbergen";
+"Previous Group" = "Vorige groep";
+"Next Group" = "Volgende groep";
+"Move Group Up" = "Groep omhoog verplaatsen";
+"Move Group Down" = "Groep omlaag verplaatsen";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "No changes" = "Geen wijzigingen";
 "(invalid)" = "(ongeldig)";
 "This backup file is invalid or corrupted." = "Dit back-upbestand is ongeldig of beschadigd.";
-"⌥-click to compare with a different backup" = "⌥-klik om te vergelijken met een andere back-up";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "Vergelijking gebruikt standaard de eerstvolgende oudere back-up. Gebruik «Wijzigingen van» om een andere te kiezen.";
 "No Backup Selected" = "Geen back-up geselecteerd";
 "Select a backup from the sidebar to preview its contents." = "Selecteer een back-up in de zijbalk om de inhoud te bekijken.";
 "selected" = "geselecteerd";

--- a/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
@@ -71,6 +71,12 @@
 "Settings Window" = "Okno ustawień";
 "Shortcuts" = "Skróty";
 "Add Group" = "Dodaj grupę";
+"Delete Group" = "Usuń grupę";
+"Toggle Sidebar" = "Przełącz pasek boczny";
+"Previous Group" = "Poprzednia grupa";
+"Next Group" = "Następna grupa";
+"Move Group Up" = "Przenieś grupę w górę";
+"Move Group Down" = "Przenieś grupę w dół";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Next Group" = "Następna grupa";
 "Move Group Up" = "Przenieś grupę w górę";
 "Move Group Down" = "Przenieś grupę w dół";
+"or" = "lub";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "Add Group" = "Dodaj grupę";
 "Delete Group" = "Usuń grupę";
 "Toggle Sidebar" = "Przełącz pasek boczny";
+"Toggle Appearance" = "Przełącz wygląd";
 "Previous Group" = "Poprzednia grupa";
 "Next Group" = "Następna grupa";
 "Move Group Up" = "Przenieś grupę w górę";

--- a/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "No changes" = "Brak zmian";
 "(invalid)" = "(nieprawidłowy)";
 "This backup file is invalid or corrupted." = "Ten plik kopii zapasowej jest nieprawidłowy lub uszkodzony.";
-"⌥-click to compare with a different backup" = "⌥-kliknij, aby porównać z inną kopią zapasową";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "Domyślnie porównuje z następną starszą kopią zapasową. Użyj opcji «Zmiany od», aby wybrać inną.";
 "No Backup Selected" = "Nie wybrano kopii zapasowej";
 "Select a backup from the sidebar to preview its contents." = "Wybierz kopię zapasową z paska bocznego, aby wyświetlić podgląd zawartości.";
 "selected" = "wybrano";

--- a/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
@@ -71,6 +71,12 @@
 "Settings Window" = "Janela de Configurações";
 "Shortcuts" = "Atalhos";
 "Add Group" = "Adicionar grupo";
+"Delete Group" = "Excluir grupo";
+"Toggle Sidebar" = "Alternar barra lateral";
+"Previous Group" = "Grupo anterior";
+"Next Group" = "Grupo seguinte";
+"Move Group Up" = "Mover grupo para cima";
+"Move Group Down" = "Mover grupo para baixo";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Next Group" = "Grupo seguinte";
 "Move Group Up" = "Mover grupo para cima";
 "Move Group Down" = "Mover grupo para baixo";
+"or" = "ou";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "No changes" = "Sem alterações";
 "(invalid)" = "(inválido)";
 "This backup file is invalid or corrupted." = "Este arquivo de backup é inválido ou está corrompido.";
-"⌥-click to compare with a different backup" = "⌥-clique para comparar com outro backup";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "A comparação usa por padrão o backup imediatamente anterior. Use «Alterações de» para escolher outro.";
 "No Backup Selected" = "Nenhum backup selecionado";
 "Select a backup from the sidebar to preview its contents." = "Selecione um backup na barra lateral para visualizar seu conteúdo.";
 "selected" = "selecionado";

--- a/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "Add Group" = "Adicionar grupo";
 "Delete Group" = "Excluir grupo";
 "Toggle Sidebar" = "Alternar barra lateral";
+"Toggle Appearance" = "Alternar aparência";
 "Previous Group" = "Grupo anterior";
 "Next Group" = "Grupo seguinte";
 "Move Group Up" = "Mover grupo para cima";

--- a/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "Add Group" = "Добавить группу";
 "Delete Group" = "Удалить группу";
 "Toggle Sidebar" = "Переключить боковую панель";
+"Toggle Appearance" = "Переключить оформление";
 "Previous Group" = "Предыдущая группа";
 "Next Group" = "Следующая группа";
 "Move Group Up" = "Переместить группу вверх";

--- a/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "No changes" = "Нет изменений";
 "(invalid)" = "(недействительный)";
 "This backup file is invalid or corrupted." = "Этот файл резервной копии недействителен или повреждён.";
-"⌥-click to compare with a different backup" = "⌥-нажмите для сравнения с другой резервной копией";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "По умолчанию сравнение выполняется с ближайшей предыдущей резервной копией. Используйте «Изменения с», чтобы выбрать другую.";
 "No Backup Selected" = "Резервная копия не выбрана";
 "Select a backup from the sidebar to preview its contents." = "Выберите резервную копию на боковой панели для предварительного просмотра содержимого.";
 "selected" = "выбрано";

--- a/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
@@ -71,6 +71,12 @@
 "Settings Window" = "Окно настроек";
 "Shortcuts" = "Горячие клавиши";
 "Add Group" = "Добавить группу";
+"Delete Group" = "Удалить группу";
+"Toggle Sidebar" = "Переключить боковую панель";
+"Previous Group" = "Предыдущая группа";
+"Next Group" = "Следующая группа";
+"Move Group Up" = "Переместить группу вверх";
+"Move Group Down" = "Переместить группу вниз";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Next Group" = "Следующая группа";
 "Move Group Up" = "Переместить группу вверх";
 "Move Group Down" = "Переместить группу вниз";
+"or" = "или";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "Add Group" = "Grup Ekle";
 "Delete Group" = "Grubu Sil";
 "Toggle Sidebar" = "Kenar Çubuğunu Aç/Kapat";
+"Toggle Appearance" = "Görünümü değiştir";
 "Previous Group" = "Önceki Grup";
 "Next Group" = "Sonraki Grup";
 "Move Group Up" = "Grubu Yukarı Taşı";

--- a/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
@@ -131,7 +131,7 @@
 "No changes" = "Değişiklik yok";
 "(invalid)" = "(geçersiz)";
 "This backup file is invalid or corrupted." = "Bu yedek dosyası geçersiz veya bozuk.";
-"⌥-click to compare with a different backup" = "⌥-tıklayarak başka bir yedekle karşılaştırın";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "Karşılaştırma varsayılan olarak bir sonraki eski yedeği kullanır. Farklı birini seçmek için «Değişiklikler» seçeneğini kullanın.";
 "No Backup Selected" = "Yedek Seçilmedi";
 "Select a backup from the sidebar to preview its contents." = "İçeriğini önizlemek için kenar çubuğundan bir yedek seçin.";
 "selected" = "seçili";

--- a/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
@@ -71,6 +71,12 @@
 "Settings Window" = "Ayarlar Penceresi";
 "Shortcuts" = "Kısayollar";
 "Add Group" = "Grup Ekle";
+"Delete Group" = "Grubu Sil";
+"Toggle Sidebar" = "Kenar Çubuğunu Aç/Kapat";
+"Previous Group" = "Önceki Grup";
+"Next Group" = "Sonraki Grup";
+"Move Group Up" = "Grubu Yukarı Taşı";
+"Move Group Down" = "Grubu Aşağı Taşı";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
@@ -77,6 +77,7 @@
 "Next Group" = "Sonraki Grup";
 "Move Group Up" = "Grubu Yukarı Taşı";
 "Move Group Down" = "Grubu Aşağı Taşı";
+"or" = "veya";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
@@ -74,6 +74,7 @@
 "Add Group" = "添加群组";
 "Delete Group" = "删除群组";
 "Toggle Sidebar" = "切换侧边栏";
+"Toggle Appearance" = "切换外观";
 "Previous Group" = "上一个群组";
 "Next Group" = "下一个群组";
 "Move Group Up" = "上移群组";

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
@@ -132,7 +132,7 @@
 "No changes" = "无更改";
 "(invalid)" = "（无效）";
 "This backup file is invalid or corrupted." = "此备份文件无效或已损坏。";
-"⌥-click to compare with a different backup" = "⌥-点击以与其他备份进行比较";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "比较默认使用下一个较早的备份。使用“更改来源”选择其他备份。";
 "No Backup Selected" = "未选择备份";
 "Select a backup from the sidebar to preview its contents." = "从侧边栏选择备份以预览其内容。";
 "selected" = "已选择";

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
@@ -72,6 +72,12 @@
 "Shortcuts" = "快捷键";
 
 "Add Group" = "添加群组";
+"Delete Group" = "删除群组";
+"Toggle Sidebar" = "切换侧边栏";
+"Previous Group" = "上一个群组";
+"Next Group" = "下一个群组";
+"Move Group Up" = "上移群组";
+"Move Group Down" = "下移群组";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 "Next Group" = "下一个群组";
 "Move Group Up" = "上移群组";
 "Move Group Down" = "下移群组";
+"or" = "或";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
@@ -72,6 +72,12 @@
 "Shortcuts" = "快速鍵";
 
 "Add Group" = "新增群組";
+"Delete Group" = "刪除群組";
+"Toggle Sidebar" = "切換側邊欄";
+"Previous Group" = "上一個群組";
+"Next Group" = "下一個群組";
+"Move Group Up" = "將群組上移";
+"Move Group Down" = "將群組下移";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
@@ -74,6 +74,7 @@
 "Add Group" = "新增群組";
 "Delete Group" = "刪除群組";
 "Toggle Sidebar" = "切換側邊欄";
+"Toggle Appearance" = "切換外觀";
 "Previous Group" = "上一個群組";
 "Next Group" = "下一個群組";
 "Move Group Up" = "將群組上移";

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
@@ -133,7 +133,7 @@
 "No changes" = "無變更";
 "(invalid)" = "（無效）";
 "This backup file is invalid or corrupted." = "此備份檔案無效或已損壞。";
-"⌥-click to compare with a different backup" = "⌥-點按以與其他備份進行比較";
+"Comparison defaults to the next older backup. Use Changes from to pick a different one." = "比較預設為下一個較早的備份。使用「變更來源」選擇其他備份。";
 "No Backup Selected" = "未選擇備份";
 "Select a backup from the sidebar to preview its contents." = "從側邊欄選擇備份以預覽其內容。";
 "selected" = "已選擇";

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 "Next Group" = "下一個群組";
 "Move Group Up" = "將群組上移";
 "Move Group Down" = "將群組下移";
+"or" = "或";
 
 
 /* Appearance Section */

--- a/ShortcutCycle/ShortcutCycle/Services/Managers/LanguageManager.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/Managers/LanguageManager.swift
@@ -91,4 +91,21 @@ class LanguageManager {
         }
         return Locale(identifier: selected)
     }
+
+    /// Syncs UserDefaults `AppleLanguages` so third-party bundles (e.g. KeyboardShortcuts)
+    /// resolve the correct localization. Some packages use region-based codes (e.g. zh-TW)
+    /// instead of script-based codes (e.g. zh-Hant); Bundle.preferredLocalizations does not
+    /// automatically bridge between them, so we map them here.
+    func syncAppleLanguages(for selectedLanguage: String) {
+        let effectiveCode = selectedLanguage == "system" ? systemLanguageCode : selectedLanguage
+        let appleCode = Self.appleCompatibleCode(for: effectiveCode)
+        UserDefaults.standard.set([appleCode], forKey: "AppleLanguages")
+    }
+
+    /// Maps app language codes to codes understood by third-party package bundles.
+    /// The KeyboardShortcuts package ships zh-TW.lproj rather than zh-Hant.lproj;
+    /// Bundle.preferredLocalizations does not match zh-Hant to zh-TW automatically.
+    private static func appleCompatibleCode(for code: String) -> String {
+        code == "zh-Hant" ? "zh-TW" : code
+    }
 }

--- a/ShortcutCycle/ShortcutCycle/Services/ShortcutManager.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/ShortcutManager.swift
@@ -34,6 +34,7 @@ class ShortcutManager: @preconcurrency ObservableObject {
     
     /// Register all shortcuts from the group store
     func registerAllShortcuts() {
+#if DEBUG
         // Register the settings toggle shortcut once.
         // KeyboardShortcuts.onKeyDown appends handlers and does not replace existing ones.
         if !hasRegisteredToggleSettingsShortcut {
@@ -44,6 +45,7 @@ class ShortcutManager: @preconcurrency ObservableObject {
             }
             hasRegisteredToggleSettingsShortcut = true
         }
+#endif
         
         // Unregister all previously registered shortcuts first
         // This is crucial to handle deleted groups or disabled groups

--- a/ShortcutCycle/ShortcutCycle/Services/ShortcutManager.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/ShortcutManager.swift
@@ -34,7 +34,6 @@ class ShortcutManager: @preconcurrency ObservableObject {
     
     /// Register all shortcuts from the group store
     func registerAllShortcuts() {
-#if DEBUG
         // Register the settings toggle shortcut once.
         // KeyboardShortcuts.onKeyDown appends handlers and does not replace existing ones.
         if !hasRegisteredToggleSettingsShortcut {
@@ -45,7 +44,6 @@ class ShortcutManager: @preconcurrency ObservableObject {
             }
             hasRegisteredToggleSettingsShortcut = true
         }
-#endif
         
         // Unregister all previously registered shortcuts first
         // This is crucial to handle deleted groups or disabled groups

--- a/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
+++ b/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
@@ -45,6 +45,7 @@ enum SettingsWindowBridge {
 struct AppCommands: Commands {
     @FocusedBinding(\.selectedTab) private var selectedTab
     @Environment(\.openWindow) private var openWindow
+    @AppStorage("appTheme") private var appTheme: AppTheme = .system
 
     private var groupsDisabled: Bool {
         selectedTab != "groups" || GroupStore.shared.groups.count < 2
@@ -97,6 +98,13 @@ struct AppCommands: Commands {
             }
             .keyboardShortcut("s", modifiers: [.command, .control])
             .disabled(selectedTab != "groups")
+
+            Button("Toggle Appearance") {
+                appTheme = appTheme.toggledAppearance(
+                    using: NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua])
+                )
+            }
+            .keyboardShortcut("a", modifiers: [.command, .control])
 
             Divider()
 
@@ -898,5 +906,20 @@ enum AppTheme: String, CaseIterable, Identifiable {
         case .light: return "sun.max.fill"
         case .dark: return "moon.fill"
         }
+    }
+
+    func toggledAppearance(using effectiveAppearanceName: NSAppearance.Name?) -> AppTheme {
+        let isCurrentlyDark: Bool
+
+        switch self {
+        case .light:
+            isCurrentlyDark = false
+        case .dark:
+            isCurrentlyDark = true
+        case .system:
+            isCurrentlyDark = effectiveAppearanceName == .darkAqua
+        }
+
+        return isCurrentlyDark ? .light : .dark
     }
 }

--- a/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
+++ b/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
@@ -244,9 +244,10 @@ struct SettingsWindowObserver: NSViewRepresentable {
         }
     }
 
-    class Coordinator {
+    final class Coordinator {
         private let onWindowWillClose: () -> Void
         private var observer: NSObjectProtocol?
+        private var keyEventMonitor: Any?
         private weak var observedWindow: NSWindow?
 
         init(onWindowWillClose: @escaping () -> Void = {}) {
@@ -255,13 +256,11 @@ struct SettingsWindowObserver: NSViewRepresentable {
 
         func observe(window: NSWindow) {
             guard observedWindow !== window else { return }
+            removeObservers()
             observedWindow = window
 
             window.identifier = NSUserInterfaceItemIdentifier("settings")
 
-            if let observer {
-                NotificationCenter.default.removeObserver(observer)
-            }
             observer = NotificationCenter.default.addObserver(
                 forName: NSWindow.willCloseNotification,
                 object: window,
@@ -274,12 +273,73 @@ struct SettingsWindowObserver: NSViewRepresentable {
                     NSApp.setActivationPolicy(.accessory)
                 }
             }
+
+            keyEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                self?.handleKeyDown(event)
+                return event
+            }
+        }
+
+        func handleKeyDown(_ event: NSEvent) {
+            guard shouldRevealFocus(for: event, in: observedWindow) else { return }
+            scheduleFocusReveal()
+        }
+
+        func shouldRevealFocus(for event: NSEvent, in window: NSWindow?) -> Bool {
+            guard let observedWindow, observedWindow === window else {
+                return false
+            }
+
+            let isObservedWindowEvent = event.window === observedWindow || event.windowNumber == observedWindow.windowNumber
+            guard isObservedWindowEvent else { return false }
+
+            return event.keyCode == 48
+        }
+
+        func scheduleFocusReveal() {
+            DispatchQueue.main.async { [weak self] in
+                self?.revealFocusedControl()
+                DispatchQueue.main.async { [weak self] in
+                    self?.revealFocusedControl()
+                }
+            }
+        }
+
+        func revealFocusedControl() {
+            guard let observedWindow,
+                  let focusedView = focusedView(in: observedWindow) else {
+                return
+            }
+
+            focusedView.scrollToVisible(focusedView.bounds.insetBy(dx: 0, dy: -20))
+        }
+
+        func focusedView(in window: NSWindow) -> NSView? {
+            if let textView = window.firstResponder as? NSTextView {
+                if let delegateView = textView.delegate as? NSView {
+                    return delegateView
+                }
+
+                return textView
+            }
+
+            return window.firstResponder as? NSView
+        }
+
+        private func removeObservers() {
+            if let observer {
+                NotificationCenter.default.removeObserver(observer)
+                self.observer = nil
+            }
+
+            if let keyEventMonitor {
+                NSEvent.removeMonitor(keyEventMonitor)
+                self.keyEventMonitor = nil
+            }
         }
 
         deinit {
-            if let o = observer {
-                NotificationCenter.default.removeObserver(o)
-            }
+            removeObservers()
         }
     }
 }

--- a/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
+++ b/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
@@ -50,9 +50,30 @@ struct AppCommands: Commands {
         selectedTab != "groups" || GroupStore.shared.groups.count < 2
     }
 
+    private var selectedGroupIndex: Int? {
+        guard let currentId = GroupStore.shared.selectedGroupId else { return nil }
+        return GroupStore.shared.groups.firstIndex(where: { $0.id == currentId })
+    }
+
+    private var canMoveGroupUp: Bool {
+        selectedTab == "groups" && (selectedGroupIndex ?? 0) > 0
+    }
+
+    private var canMoveGroupDown: Bool {
+        guard let selectedGroupIndex else { return false }
+        return selectedTab == "groups" && selectedGroupIndex < GroupStore.shared.groups.count - 1
+    }
+
     var body: some Commands {
         // Keep a non-lazy reference to openWindow for URL/shortcut cold-start requests.
         let _ = SettingsWindowBridge.register(openWindow: openWindow)
+
+        CommandGroup(replacing: .appSettings) {
+            Button("Settings...") {
+                ShortcutCycleURLRouter.openSettingsFromOutsideView(tab: .general)
+            }
+            .keyboardShortcut(",", modifiers: .command)
+        }
 
         CommandGroup(replacing: .newItem) {
             Button("Add Group") {
@@ -133,6 +154,20 @@ struct AppCommands: Commands {
             }
             .keyboardShortcut("j", modifiers: .command)
             .disabled(groupsDisabled)
+
+            Divider()
+
+            Button("Move Group Up") {
+                moveSelectedGroup(by: -1)
+            }
+            .keyboardShortcut(.upArrow, modifiers: [.command, .option])
+            .disabled(!canMoveGroupUp)
+
+            Button("Move Group Down") {
+                moveSelectedGroup(by: 1)
+            }
+            .keyboardShortcut(.downArrow, modifiers: [.command, .option])
+            .disabled(!canMoveGroupDown)
         }
     }
 
@@ -158,6 +193,21 @@ struct AppCommands: Commands {
         }
         let nextIndex = currentIndex == store.groups.count - 1 ? 0 : currentIndex + 1
         store.selectedGroupId = store.groups[nextIndex].id
+    }
+
+    private func moveSelectedGroup(by delta: Int) {
+        let store = GroupStore.shared
+        guard let currentId = store.selectedGroupId,
+              let currentIndex = store.groups.firstIndex(where: { $0.id == currentId }) else {
+            return
+        }
+
+        let targetIndex = currentIndex + delta
+        guard store.groups.indices.contains(targetIndex) else { return }
+
+        let destination = delta > 0 ? targetIndex + 1 : targetIndex
+        store.moveGroups(from: IndexSet(integer: currentIndex), to: destination)
+        store.selectedGroupId = currentId
     }
 }
 

--- a/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
+++ b/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
@@ -268,7 +268,6 @@ struct SettingsWindowObserver: NSViewRepresentable {
             observedWindow = window
 
             window.identifier = NSUserInterfaceItemIdentifier("settings")
-            configureChrome(for: window)
 
             observer = NotificationCenter.default.addObserver(
                 forName: NSWindow.willCloseNotification,
@@ -333,14 +332,6 @@ struct SettingsWindowObserver: NSViewRepresentable {
             }
 
             return window.firstResponder as? NSView
-        }
-
-        func configureChrome(for window: NSWindow) {
-            window.titlebarAppearsTransparent = true
-            window.isMovableByWindowBackground = true
-            window.backgroundColor = .windowBackgroundColor
-            window.toolbarStyle = .unified
-            window.toolbar?.showsBaselineSeparator = false
         }
 
         private func removeObservers() {

--- a/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
+++ b/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
@@ -268,6 +268,7 @@ struct SettingsWindowObserver: NSViewRepresentable {
             observedWindow = window
 
             window.identifier = NSUserInterfaceItemIdentifier("settings")
+            configureChrome(for: window)
 
             observer = NotificationCenter.default.addObserver(
                 forName: NSWindow.willCloseNotification,
@@ -332,6 +333,14 @@ struct SettingsWindowObserver: NSViewRepresentable {
             }
 
             return window.firstResponder as? NSView
+        }
+
+        func configureChrome(for window: NSWindow) {
+            window.titlebarAppearsTransparent = true
+            window.isMovableByWindowBackground = true
+            window.backgroundColor = .windowBackgroundColor
+            window.toolbarStyle = .unified
+            window.toolbar?.showsBaselineSeparator = false
         }
 
         private func removeObservers() {

--- a/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
+++ b/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
@@ -431,6 +431,7 @@ enum ShortcutCycleURLRouter {
         case .backup:
             _ = store.manualBackup()
         case .flushAutoSave:
+            store.flushPendingSave()
             store.flushPendingBackup()
         case .setSetting(let key, let value):
             applySetting(key: key, value: value)
@@ -603,6 +604,7 @@ enum ShortcutCycleURLRouter {
             let supportedCodes = LanguageManager.shared.supportedLanguages.map(\.code)
             guard let language = URLRouterLogic.parseLanguage(value, supportedCodes: supportedCodes) else { return }
             UserDefaults.standard.set(language, forKey: "selectedLanguage")
+            LanguageManager.shared.syncAppleLanguages(for: language)
         case "openatlogin", "launchatlogin":
             guard let boolValue = URLRouterLogic.parseBool(value) else { return }
             LaunchAtLoginManager.shared.isEnabled = boolValue
@@ -793,6 +795,10 @@ struct ShortcutCycleApp: App {
         Task { @MainActor in
             ShortcutManager.shared.registerAllShortcuts()
         }
+        // Sync AppleLanguages so third-party bundles (e.g. KeyboardShortcuts) use the
+        // correct locale. Must run before any view creates a KeyboardShortcuts.Recorder.
+        let selected = UserDefaults.standard.string(forKey: "selectedLanguage") ?? "system"
+        LanguageManager.shared.syncAppleLanguages(for: selected)
     }
 
     var body: some Scene {

--- a/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
+++ b/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
@@ -811,6 +811,7 @@ struct ShortcutCycleApp: App {
                 .environmentObject(localeObserver)
         }
         .defaultSize(width: 700, height: 500)
+        .windowToolbarStyle(.unified(showsTitle: false))
         .commands {
             AppCommands()
         }

--- a/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
@@ -172,7 +172,7 @@ struct AppDropZoneView: View {
             RoundedRectangle(cornerRadius: 12)
                 .strokeBorder(
                     SettingsChromePalette.dropZoneBorder(for: colorScheme, targeted: isTargeted),
-                    style: StrokeStyle(lineWidth: colorScheme == .dark ? 1.5 : 2, dash: [8])
+                    style: StrokeStyle(lineWidth: colorScheme == .dark ? 2 : 2, dash: [8])
                 )
         )
         .contentShape(Rectangle())

--- a/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
@@ -122,32 +122,35 @@ struct AppDropZoneView: View {
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     
     var body: some View {
-        VStack(spacing: 10) {
-            Image(systemName: "plus.app")
-                .font(.system(size: 28))
-                .foregroundColor(isTargeted ? .accentColor : .secondary)
-            
-            Text("Drop or click to add apps".localized(language: selectedLanguage))
-                .font(.caption)
-                .foregroundColor(isTargeted ? .accentColor : .secondary)
+        Button(action: openFilePicker) {
+            VStack(spacing: 10) {
+                Image(systemName: "plus.app")
+                    .font(.system(size: 28))
+                    .foregroundColor(isTargeted ? .accentColor : .secondary)
+
+                Text("Drop or click to add apps".localized(language: selectedLanguage))
+                    .font(.caption.weight(.medium))
+                    .foregroundColor(isTargeted ? .accentColor : .secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 112)
+            .padding(.horizontal, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(
+                        style: StrokeStyle(lineWidth: 2, dash: [8])
+                    )
+                    .foregroundColor(isTargeted ? .accentColor : .gray.opacity(0.3))
+            )
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isTargeted ? Color.accentColor.opacity(0.1) : Color.clear)
+            )
         }
-        .frame(maxWidth: .infinity)
-        .frame(height: 112)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(
-                    style: StrokeStyle(lineWidth: 2, dash: [8])
-                )
-                .foregroundColor(isTargeted ? .accentColor : .gray.opacity(0.3))
-        )
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(isTargeted ? Color.accentColor.opacity(0.1) : Color.clear)
-        )
-        .contentShape(Rectangle())
-        .onTapGesture {
-            openFilePicker()
-        }
+        .buttonStyle(.plain)
+        .help("Select applications to add to this group".localized(language: selectedLanguage))
+        .accessibilityLabel("Add Apps".localized(language: selectedLanguage))
+        .accessibilityHint("Select applications to add to this group".localized(language: selectedLanguage))
         .onDrop(of: [.fileURL], isTargeted: $isTargeted) { providers in
             handleDrop(providers: providers)
         }

--- a/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
@@ -29,6 +29,7 @@ struct AppIconThumbnailView: View {
 struct AppRowView: View {
     let app: AppItem
     let onDelete: () -> Void
+    @Environment(\.colorScheme) private var colorScheme
     
     var body: some View {
         HStack(spacing: 12) {
@@ -61,7 +62,11 @@ struct AppRowView: View {
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
-        .background(Color(nsColor: .controlBackgroundColor))
+        .background(
+            colorScheme == .dark
+                ? SettingsChromePalette.panelBackground(for: colorScheme)
+                : Color(nsColor: .controlBackgroundColor)
+        )
         .cornerRadius(8)
     }
 }
@@ -71,6 +76,7 @@ struct AppGridItemView: View {
     let app: AppItem
     let isPlaceholder: Bool
     let onDelete: () -> Void
+    @Environment(\.colorScheme) private var colorScheme
     @State private var isHovered = false
 
     init(app: AppItem, isPlaceholder: Bool = false, onDelete: @escaping () -> Void) {
@@ -108,14 +114,26 @@ struct AppGridItemView: View {
             RoundedRectangle(cornerRadius: 8)
                 .fill(
                     isPlaceholder
-                    ? Color.secondary.opacity(0.05)
-                    : (isHovered ? Color.accentColor.opacity(0.1) : Color.clear)
+                    ? (colorScheme == .dark
+                        ? SettingsChromePalette.neutralHoverFill(for: colorScheme).opacity(0.45)
+                        : Color.secondary.opacity(0.05))
+                    : (isHovered
+                        ? (colorScheme == .dark
+                            ? SettingsChromePalette.neutralHoverFill(for: colorScheme)
+                            : Color.accentColor.opacity(0.1))
+                        : Color.clear)
                 )
         )
         .overlay(
             RoundedRectangle(cornerRadius: 8)
                 .stroke(
-                    isPlaceholder ? Color.secondary.opacity(0.18) : Color.clear,
+                    isPlaceholder
+                        ? (colorScheme == .dark
+                            ? SettingsChromePalette.neutralHoverBorder(for: colorScheme)
+                            : Color.secondary.opacity(0.18))
+                        : ((colorScheme == .dark && isHovered)
+                            ? SettingsChromePalette.neutralHoverBorder(for: colorScheme)
+                            : Color.clear),
                     style: StrokeStyle(lineWidth: 1, dash: [5, 4])
                 )
         )
@@ -132,6 +150,7 @@ struct AppDropZoneView: View {
     @State private var isTargeted = false
     let onAppAdded: (AppItem) -> Void
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
+    @Environment(\.colorScheme) private var colorScheme
     
     var body: some View {
         VStack(spacing: 10) {
@@ -147,14 +166,14 @@ struct AppDropZoneView: View {
         .frame(height: 112)
         .background(
             RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(
-                    style: StrokeStyle(lineWidth: 2, dash: [8])
-                )
-                .foregroundColor(isTargeted ? .accentColor : .gray.opacity(0.3))
+                .fill(SettingsChromePalette.dropZoneFill(for: colorScheme, targeted: isTargeted))
         )
-        .background(
+        .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .fill(isTargeted ? Color.accentColor.opacity(0.1) : Color.clear)
+                .strokeBorder(
+                    SettingsChromePalette.dropZoneBorder(for: colorScheme, targeted: isTargeted),
+                    style: StrokeStyle(lineWidth: colorScheme == .dark ? 1.5 : 2, dash: [8])
+                )
         )
         .contentShape(Rectangle())
         .onTapGesture {

--- a/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
@@ -4,6 +4,27 @@ import ShortcutCycleCore
 #endif
 import UniformTypeIdentifiers
 
+struct AppIconThumbnailView: View {
+    let app: AppItem
+    let size: CGFloat
+    let fallbackFontSize: CGFloat
+
+    var body: some View {
+        Group {
+            if let icon = IconCache.shared.getIcon(for: app) {
+                Image(nsImage: icon)
+                    .resizable()
+                    .frame(width: size, height: size)
+            } else {
+                Image(systemName: "app.fill")
+                    .font(.system(size: fallbackFontSize))
+                    .foregroundColor(.secondary)
+                    .frame(width: size, height: size)
+            }
+        }
+    }
+}
+
 /// A row representing a single app in the group list
 struct AppRowView: View {
     let app: AppItem
@@ -11,22 +32,7 @@ struct AppRowView: View {
     
     var body: some View {
         HStack(spacing: 12) {
-            // App icon
-            if let iconPath = app.iconPath,
-               let icon = NSWorkspace.shared.icon(forFile: iconPath + "/Contents/Resources/AppIcon.icns") as NSImage? {
-                Image(nsImage: icon)
-                    .resizable()
-                    .frame(width: 32, height: 32)
-            } else if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: app.bundleIdentifier) {
-                Image(nsImage: NSWorkspace.shared.icon(forFile: appURL.path))
-                    .resizable()
-                    .frame(width: 32, height: 32)
-            } else {
-                Image(systemName: "app.fill")
-                    .font(.system(size: 24))
-                    .foregroundColor(.secondary)
-                    .frame(width: 32, height: 32)
-            }
+            AppIconThumbnailView(app: app, size: 32, fallbackFontSize: 24)
             
             VStack(alignment: .leading, spacing: 2) {
                 Text(app.name)
@@ -70,18 +76,7 @@ struct AppGridItemView: View {
     var body: some View {
         Button(action: onSelect) {
             VStack(spacing: 8) {
-                Group {
-                    if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: app.bundleIdentifier) {
-                        Image(nsImage: NSWorkspace.shared.icon(forFile: appURL.path))
-                            .resizable()
-                            .frame(width: 56, height: 56)
-                    } else {
-                        Image(systemName: "app.fill")
-                            .font(.system(size: 42))
-                            .foregroundColor(.secondary)
-                            .frame(width: 56, height: 56)
-                    }
-                }
+                AppIconThumbnailView(app: app, size: 56, fallbackFontSize: 42)
     
                 Text(app.name)
                     .font(.caption)

--- a/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
@@ -69,37 +69,60 @@ struct AppRowView: View {
 /// A grid item representing a single app with icon and name
 struct AppGridItemView: View {
     let app: AppItem
-    let isSelected: Bool
-    let onSelect: () -> Void
+    let isPlaceholder: Bool
+    let onDelete: () -> Void
     @State private var isHovered = false
+
+    init(app: AppItem, isPlaceholder: Bool = false, onDelete: @escaping () -> Void) {
+        self.app = app
+        self.isPlaceholder = isPlaceholder
+        self.onDelete = onDelete
+    }
     
     var body: some View {
-        Button(action: onSelect) {
-            VStack(spacing: 8) {
+        VStack(spacing: 8) {
+            ZStack(alignment: .topTrailing) {
                 AppIconThumbnailView(app: app, size: 56, fallbackFontSize: 42)
-    
-                Text(app.name)
-                    .font(.caption)
-                    .lineLimit(2)
-                    .multilineTextAlignment(.center)
-                    .frame(width: 88)
+
+                if isHovered && !isPlaceholder {
+                    Button(action: onDelete) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 16))
+                            .foregroundColor(.white)
+                            .background(Circle().fill(Color.red))
+                    }
+                    .buttonStyle(.plain)
+                    .offset(x: 6, y: -6)
+                }
             }
-            .padding(10)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill((isHovered || isSelected) ? Color.accentColor.opacity(0.1) : Color.clear)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(isSelected ? Color.accentColor.opacity(0.35) : Color.clear, lineWidth: 1)
-            )
+
+            Text(app.name)
+                .font(.caption)
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+                .frame(width: 88)
         }
-        .buttonStyle(.plain)
+        .opacity(isPlaceholder ? 0.12 : 1)
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(
+                    isPlaceholder
+                    ? Color.secondary.opacity(0.05)
+                    : (isHovered ? Color.accentColor.opacity(0.1) : Color.clear)
+                )
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(
+                    isPlaceholder ? Color.secondary.opacity(0.18) : Color.clear,
+                    style: StrokeStyle(lineWidth: 1, dash: [5, 4])
+                )
+        )
         .onHover { hovering in
-            isHovered = hovering
+            isHovered = isPlaceholder ? false : hovering
         }
         .help(app.bundleIdentifier)
-        .accessibilityLabel(app.name)
     }
 }
 
@@ -111,35 +134,32 @@ struct AppDropZoneView: View {
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     
     var body: some View {
-        Button(action: openFilePicker) {
-            VStack(spacing: 10) {
-                Image(systemName: "plus.app")
-                    .font(.system(size: 28))
-                    .foregroundColor(isTargeted ? .accentColor : .secondary)
+        VStack(spacing: 10) {
+            Image(systemName: "plus.app")
+                .font(.system(size: 28))
+                .foregroundColor(isTargeted ? .accentColor : .secondary)
 
-                Text("Drop or click to add apps".localized(language: selectedLanguage))
-                    .font(.caption.weight(.medium))
-                    .foregroundColor(isTargeted ? .accentColor : .secondary)
-            }
-            .frame(maxWidth: .infinity)
-            .frame(height: 112)
-            .padding(.horizontal, 12)
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .strokeBorder(
-                        style: StrokeStyle(lineWidth: 2, dash: [8])
-                    )
-                    .foregroundColor(isTargeted ? .accentColor : .gray.opacity(0.3))
-            )
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(isTargeted ? Color.accentColor.opacity(0.1) : Color.clear)
-            )
+            Text("Drop or click to add apps".localized(language: selectedLanguage))
+                .font(.caption)
+                .foregroundColor(isTargeted ? .accentColor : .secondary)
         }
-        .buttonStyle(.plain)
-        .help("Select applications to add to this group".localized(language: selectedLanguage))
-        .accessibilityLabel("Add Apps".localized(language: selectedLanguage))
-        .accessibilityHint("Select applications to add to this group".localized(language: selectedLanguage))
+        .frame(maxWidth: .infinity)
+        .frame(height: 112)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(
+                    style: StrokeStyle(lineWidth: 2, dash: [8])
+                )
+                .foregroundColor(isTargeted ? .accentColor : .gray.opacity(0.3))
+        )
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(isTargeted ? Color.accentColor.opacity(0.1) : Color.clear)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            openFilePicker()
+        }
         .onDrop(of: [.fileURL], isTargeted: $isTargeted) { providers in
             handleDrop(providers: providers)
         }

--- a/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
@@ -63,13 +63,13 @@ struct AppRowView: View {
 /// A grid item representing a single app with icon and name
 struct AppGridItemView: View {
     let app: AppItem
-    let onDelete: () -> Void
+    let isSelected: Bool
+    let onSelect: () -> Void
     @State private var isHovered = false
     
     var body: some View {
-        VStack(spacing: 8) {
-            ZStack(alignment: .topTrailing) {
-                // App icon
+        Button(action: onSelect) {
+            VStack(spacing: 8) {
                 Group {
                     if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: app.bundleIdentifier) {
                         Image(nsImage: NSWorkspace.shared.icon(forFile: appURL.path))
@@ -82,35 +82,29 @@ struct AppGridItemView: View {
                             .frame(width: 56, height: 56)
                     }
                 }
-                
-                // Delete button (visible on hover)
-                if isHovered {
-                    Button(action: onDelete) {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 16))
-                            .foregroundColor(.white)
-                            .background(Circle().fill(Color.red))
-                    }
-                    .buttonStyle(.plain)
-                    .offset(x: 6, y: -6)
-                }
+    
+                Text(app.name)
+                    .font(.caption)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .frame(width: 88)
             }
-            
-            Text(app.name)
-                .font(.caption)
-                .lineLimit(2)
-                .multilineTextAlignment(.center)
-                .frame(width: 88)
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill((isHovered || isSelected) ? Color.accentColor.opacity(0.1) : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isSelected ? Color.accentColor.opacity(0.35) : Color.clear, lineWidth: 1)
+            )
         }
-        .padding(10)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(isHovered ? Color.accentColor.opacity(0.1) : Color.clear)
-        )
+        .buttonStyle(.plain)
         .onHover { hovering in
             isHovered = hovering
         }
         .help(app.bundleIdentifier)
+        .accessibilityLabel(app.name)
     }
 }
 

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -15,10 +15,10 @@ struct GroupEditView: View {
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     @State private var groupName: String = ""
     @State private var draggingApp: AppItem?
+    @State private var dragPreviewApps: [AppItem]?
     @State private var isHovering: Bool = false
     @FocusState private var isNameFocused: Bool
     @State private var suppressAutoFocus = true
-    @State private var selectedAppId: UUID?
     @State private var quickAddCandidates: [AppItem] = []
 
     init(
@@ -58,8 +58,8 @@ struct GroupEditView: View {
                 suppressAutoFocus = false
             }
         }
-        .onChange(of: group?.apps.map(\.bundleIdentifier) ?? []) { _, _ in
-            syncSelectedApp()
+        .onChange(of: (group?.apps.map(\.bundleIdentifier).sorted()) ?? []) { _, _ in
+            dragPreviewApps = nil
             refreshQuickAddCandidates()
         }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didLaunchApplicationNotification)) { _ in
@@ -122,6 +122,8 @@ struct GroupEditView: View {
     }
 
     private func appsSection(for group: AppGroup) -> some View {
+        let displayedApps = dragPreviewApps ?? group.apps
+
         return VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Text("Applications".localized(language: selectedLanguage))
@@ -141,14 +143,13 @@ struct GroupEditView: View {
                     .padding(.vertical, 8)
             } else {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 80, maximum: 100))], spacing: 16) {
-                    ForEach(group.apps) { app in
+                    ForEach(displayedApps) { app in
                         AppGridItemView(
                             app: app,
-                            isSelected: selectedAppId == app.id
+                            isPlaceholder: draggingApp?.id == app.id
                         ) {
-                            selectedAppId = app.id
+                            store.removeApp(app, from: groupId)
                         }
-                        .opacity(draggingApp?.id == app.id ? 0.01 : 1)
                         .onDrag {
                             draggingApp = app
                             return NSItemProvider(object: app.id.uuidString as NSString)
@@ -156,15 +157,14 @@ struct GroupEditView: View {
                         .onDrop(of: [.text], delegate: AppReorderDelegate(
                             item: app,
                             draggingApp: $draggingApp,
+                            dragPreviewApps: $dragPreviewApps,
                             store: store,
                             groupId: groupId
                         ))
                     }
                 }
                 .padding(.vertical, 8)
-                .animation(.default, value: group.apps)
-
-                selectedAppControls(for: group)
+                .animation(.default, value: displayedApps)
             }
 
             addAppsPanel(for: group, quickAddCandidates: quickAddCandidates)
@@ -247,102 +247,8 @@ struct GroupEditView: View {
         if let group = group {
             groupName = group.name
         }
-        syncSelectedApp()
+        dragPreviewApps = nil
         refreshQuickAddCandidates()
-    }
-
-    private func syncSelectedApp() {
-        guard let group else {
-            selectedAppId = nil
-            return
-        }
-
-        if let selectedAppId,
-           group.apps.contains(where: { $0.id == selectedAppId }) {
-            return
-        }
-
-        selectedAppId = group.apps.first?.id
-    }
-
-    private func selectedAppIndex(in group: AppGroup) -> Int? {
-        guard let selectedAppId else { return nil }
-        return group.apps.firstIndex(where: { $0.id == selectedAppId })
-    }
-
-    private func moveSelectedApp(in group: AppGroup, by delta: Int) {
-        guard let currentIndex = selectedAppIndex(in: group) else { return }
-        let targetIndex = currentIndex + delta
-        guard group.apps.indices.contains(targetIndex) else { return }
-
-        let destination = delta > 0 ? targetIndex + 1 : targetIndex
-        store.moveApp(in: groupId, from: IndexSet(integer: currentIndex), to: destination)
-    }
-
-    private func removeSelectedApp(from group: AppGroup) {
-        guard let currentIndex = selectedAppIndex(in: group) else { return }
-
-        let replacementSelection: UUID? = {
-            let nextIndex = currentIndex + 1
-            if group.apps.indices.contains(nextIndex) {
-                return group.apps[nextIndex].id
-            }
-            let previousIndex = currentIndex - 1
-            if group.apps.indices.contains(previousIndex) {
-                return group.apps[previousIndex].id
-            }
-            return nil
-        }()
-
-        store.removeApp(group.apps[currentIndex], from: groupId)
-        selectedAppId = replacementSelection
-    }
-
-    private func selectedAppControls(for group: AppGroup) -> some View {
-        let selectedIndex = selectedAppIndex(in: group)
-        let selectedAppName = selectedIndex.flatMap { group.apps[$0].name }
-
-        return HStack(spacing: 8) {
-            if let selectedAppName {
-                Text(selectedAppName)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .lineLimit(1)
-            }
-
-            Spacer()
-
-            Button {
-                moveSelectedApp(in: group, by: -1)
-            } label: {
-                Image(systemName: "arrow.left")
-            }
-            .buttonStyle(.borderless)
-            .disabled((selectedIndex ?? 0) <= 0)
-            .help("Move selected app earlier in the cycle")
-            .accessibilityLabel("Move selected app earlier in the cycle")
-
-            Button {
-                moveSelectedApp(in: group, by: 1)
-            } label: {
-                Image(systemName: "arrow.right")
-            }
-            .buttonStyle(.borderless)
-            .disabled(selectedIndex == nil || selectedIndex == group.apps.count - 1)
-            .help("Move selected app later in the cycle")
-            .accessibilityLabel("Move selected app later in the cycle")
-
-            Button(role: .destructive) {
-                removeSelectedApp(from: group)
-            } label: {
-                Image(systemName: "trash")
-            }
-            .buttonStyle(.borderless)
-            .disabled(selectedIndex == nil)
-            .help("Remove selected app from the group")
-            .accessibilityLabel("Remove selected app from the group")
-        }
-        .padding(.top, 4)
     }
 
     private func refreshQuickAddCandidates() {
@@ -495,6 +401,7 @@ private struct GroupShortcutEditor: View {
                     .font(.caption)
                     .labelsHidden()
                     .fixedSize(horizontal: true, vertical: false)
+                    .focusable()
 
                     Picker("Cycling Mode".localized(language: selectedLanguage), selection: cyclingModeSelection) {
                         Text("Running apps only".localized(language: selectedLanguage)).tag(false)
@@ -503,6 +410,7 @@ private struct GroupShortcutEditor: View {
                     .pickerStyle(.menu)
                     .font(.caption)
                     .labelsHidden()
+                    .focusable()
                 }
             }
 
@@ -558,6 +466,7 @@ private struct ShortcutSuggestionRow: View {
                             )
                     }
                     .buttonStyle(.plain)
+                    .focusable()
                     .help(shortcut.description)
                 }
             }
@@ -572,19 +481,26 @@ private struct ShortcutSuggestionRow: View {
 struct AppReorderDelegate: DropDelegate {
     let item: AppItem
     @Binding var draggingApp: AppItem?
+    @Binding var dragPreviewApps: [AppItem]?
     let store: GroupStore
     let groupId: UUID
 
     func dropEntered(info: DropInfo) {
-        guard let draggingApp = draggingApp,
-              draggingApp.id != item.id,
-              let group = store.groups.first(where: { $0.id == groupId }),
-              let fromIndex = group.apps.firstIndex(of: draggingApp),
-              let toIndex = group.apps.firstIndex(of: item)
+        guard let draggingApp,
+              draggingApp.id != item.id
+        else { return }
+
+        let currentApps = dragPreviewApps ?? store.groups.first(where: { $0.id == groupId })?.apps ?? []
+        guard let fromIndex = currentApps.firstIndex(of: draggingApp),
+              let toIndex = currentApps.firstIndex(of: item)
         else { return }
 
         let destination = toIndex > fromIndex ? toIndex + 1 : toIndex
-        store.moveApp(in: groupId, from: IndexSet(integer: fromIndex), to: destination)
+        var updatedApps = currentApps
+        updatedApps.move(fromOffsets: IndexSet(integer: fromIndex), toOffset: destination)
+
+        guard updatedApps != currentApps else { return }
+        dragPreviewApps = updatedApps
     }
 
     func dropUpdated(info: DropInfo) -> DropProposal? {
@@ -592,7 +508,13 @@ struct AppReorderDelegate: DropDelegate {
     }
 
     func performDrop(info: DropInfo) -> Bool {
-        draggingApp = nil
+        defer {
+            draggingApp = nil
+            dragPreviewApps = nil
+        }
+
+        guard let previewApps = dragPreviewApps else { return true }
+        store.replaceApps(in: groupId, with: previewApps)
         return true
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -18,8 +18,8 @@ struct GroupEditView: View {
     @State private var isHovering: Bool = false
     @FocusState private var isNameFocused: Bool
     @State private var suppressAutoFocus = true
-    @State private var runningAppsRefreshToken = 0
     @State private var selectedAppId: UUID?
+    @State private var quickAddCandidates: [AppItem] = []
 
     init(
         groupId: UUID,
@@ -58,14 +58,15 @@ struct GroupEditView: View {
                 suppressAutoFocus = false
             }
         }
-        .onChange(of: group?.apps.map(\.id) ?? []) { _, _ in
+        .onChange(of: group?.apps.map(\.bundleIdentifier) ?? []) { _, _ in
             syncSelectedApp()
+            refreshQuickAddCandidates()
         }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didLaunchApplicationNotification)) { _ in
-            runningAppsRefreshToken += 1
+            refreshQuickAddCandidates()
         }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didTerminateApplicationNotification)) { _ in
-            runningAppsRefreshToken += 1
+            refreshQuickAddCandidates()
         }
     }
 
@@ -121,8 +122,6 @@ struct GroupEditView: View {
     }
 
     private func appsSection(for group: AppGroup) -> some View {
-        let quickAddCandidates = runningAppCandidates(for: group)
-
         return VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Text("Applications".localized(language: selectedLanguage))
@@ -249,6 +248,7 @@ struct GroupEditView: View {
             groupName = group.name
         }
         syncSelectedApp()
+        refreshQuickAddCandidates()
     }
 
     private func syncSelectedApp() {
@@ -345,9 +345,13 @@ struct GroupEditView: View {
         .padding(.top, 4)
     }
 
-    private func runningAppCandidates(for group: AppGroup) -> [AppItem] {
-        _ = runningAppsRefreshToken
-        return runningAppCandidatesProvider(group.apps)
+    private func refreshQuickAddCandidates() {
+        guard let group else {
+            quickAddCandidates = []
+            return
+        }
+
+        quickAddCandidates = runningAppCandidatesProvider(group.apps)
     }
 
     private static func defaultRunningAppCandidates(for groupApps: [AppItem]) -> [AppItem] {
@@ -383,18 +387,7 @@ private struct RunningAppQuickAddButton: View {
         Button(action: onAdd) {
             VStack(spacing: 6) {
                 ZStack(alignment: .topTrailing) {
-                    Group {
-                        if let appURL = NSWorkspace.shared.urlForApplication(withBundleIdentifier: app.bundleIdentifier) {
-                            Image(nsImage: NSWorkspace.shared.icon(forFile: appURL.path))
-                                .resizable()
-                                .frame(width: 30, height: 30)
-                        } else {
-                            Image(systemName: "app.fill")
-                                .font(.system(size: 24))
-                                .foregroundColor(.secondary)
-                                .frame(width: 30, height: 30)
-                        }
-                    }
+                    AppIconThumbnailView(app: app, size: 30, fallbackFontSize: 24)
 
                     Image(systemName: "plus.circle.fill")
                         .font(.system(size: 12, weight: .semibold))

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -395,6 +395,7 @@ private struct GroupShortcutEditor: View {
             VStack(alignment: .leading, spacing: 8) {
                 KeyboardShortcuts.Recorder(for: shortcutName, onChange: handleShortcutChange)
                     .padding(.leading, 4)
+                    .id(selectedLanguage) // Recreate on language change so placeholder re-reads AppleLanguages
 
                 if shouldShowSuggestions {
                     ShortcutSuggestionRow(

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -401,7 +401,6 @@ private struct GroupShortcutEditor: View {
                     .font(.caption)
                     .labelsHidden()
                     .fixedSize(horizontal: true, vertical: false)
-                    .focusable()
 
                     Picker("Cycling Mode".localized(language: selectedLanguage), selection: cyclingModeSelection) {
                         Text("Running apps only".localized(language: selectedLanguage)).tag(false)
@@ -410,7 +409,6 @@ private struct GroupShortcutEditor: View {
                     .pickerStyle(.menu)
                     .font(.caption)
                     .labelsHidden()
-                    .focusable()
                 }
             }
 
@@ -466,7 +464,6 @@ private struct ShortcutSuggestionRow: View {
                             )
                     }
                     .buttonStyle(.plain)
-                    .focusable()
                     .help(shortcut.description)
                 }
             }
@@ -486,6 +483,10 @@ struct AppReorderDelegate: DropDelegate {
     let groupId: UUID
 
     func dropEntered(info: DropInfo) {
+        updatePreviewOrder()
+    }
+
+    func updatePreviewOrder() {
         guard let draggingApp,
               draggingApp.id != item.id
         else { return }
@@ -508,14 +509,18 @@ struct AppReorderDelegate: DropDelegate {
     }
 
     func performDrop(info: DropInfo) -> Bool {
+        commitPreviewOrder()
+        return true
+    }
+
+    func commitPreviewOrder() {
         defer {
             draggingApp = nil
             dragPreviewApps = nil
         }
 
-        guard let previewApps = dragPreviewApps else { return true }
+        guard let previewApps = dragPreviewApps else { return }
         store.replaceApps(in: groupId, with: previewApps)
-        return true
     }
 }
 

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -19,6 +19,7 @@ struct GroupEditView: View {
     @FocusState private var isNameFocused: Bool
     @State private var suppressAutoFocus = true
     @State private var runningAppsRefreshToken = 0
+    @State private var selectedAppId: UUID?
 
     init(
         groupId: UUID,
@@ -56,6 +57,9 @@ struct GroupEditView: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 suppressAutoFocus = false
             }
+        }
+        .onChange(of: group?.apps.map(\.id) ?? []) { _, _ in
+            syncSelectedApp()
         }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didLaunchApplicationNotification)) { _ in
             runningAppsRefreshToken += 1
@@ -139,8 +143,11 @@ struct GroupEditView: View {
             } else {
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 80, maximum: 100))], spacing: 16) {
                     ForEach(group.apps) { app in
-                        AppGridItemView(app: app) {
-                            store.removeApp(app, from: groupId)
+                        AppGridItemView(
+                            app: app,
+                            isSelected: selectedAppId == app.id
+                        ) {
+                            selectedAppId = app.id
                         }
                         .opacity(draggingApp?.id == app.id ? 0.01 : 1)
                         .onDrag {
@@ -157,6 +164,8 @@ struct GroupEditView: View {
                 }
                 .padding(.vertical, 8)
                 .animation(.default, value: group.apps)
+
+                selectedAppControls(for: group)
             }
 
             addAppsPanel(for: group, quickAddCandidates: quickAddCandidates)
@@ -239,6 +248,101 @@ struct GroupEditView: View {
         if let group = group {
             groupName = group.name
         }
+        syncSelectedApp()
+    }
+
+    private func syncSelectedApp() {
+        guard let group else {
+            selectedAppId = nil
+            return
+        }
+
+        if let selectedAppId,
+           group.apps.contains(where: { $0.id == selectedAppId }) {
+            return
+        }
+
+        selectedAppId = group.apps.first?.id
+    }
+
+    private func selectedAppIndex(in group: AppGroup) -> Int? {
+        guard let selectedAppId else { return nil }
+        return group.apps.firstIndex(where: { $0.id == selectedAppId })
+    }
+
+    private func moveSelectedApp(in group: AppGroup, by delta: Int) {
+        guard let currentIndex = selectedAppIndex(in: group) else { return }
+        let targetIndex = currentIndex + delta
+        guard group.apps.indices.contains(targetIndex) else { return }
+
+        let destination = delta > 0 ? targetIndex + 1 : targetIndex
+        store.moveApp(in: groupId, from: IndexSet(integer: currentIndex), to: destination)
+    }
+
+    private func removeSelectedApp(from group: AppGroup) {
+        guard let currentIndex = selectedAppIndex(in: group) else { return }
+
+        let replacementSelection: UUID? = {
+            let nextIndex = currentIndex + 1
+            if group.apps.indices.contains(nextIndex) {
+                return group.apps[nextIndex].id
+            }
+            let previousIndex = currentIndex - 1
+            if group.apps.indices.contains(previousIndex) {
+                return group.apps[previousIndex].id
+            }
+            return nil
+        }()
+
+        store.removeApp(group.apps[currentIndex], from: groupId)
+        selectedAppId = replacementSelection
+    }
+
+    private func selectedAppControls(for group: AppGroup) -> some View {
+        let selectedIndex = selectedAppIndex(in: group)
+        let selectedAppName = selectedIndex.flatMap { group.apps[$0].name }
+
+        return HStack(spacing: 8) {
+            if let selectedAppName {
+                Text(selectedAppName)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Button {
+                moveSelectedApp(in: group, by: -1)
+            } label: {
+                Image(systemName: "arrow.left")
+            }
+            .buttonStyle(.borderless)
+            .disabled((selectedIndex ?? 0) <= 0)
+            .help("Move selected app earlier in the cycle")
+            .accessibilityLabel("Move selected app earlier in the cycle")
+
+            Button {
+                moveSelectedApp(in: group, by: 1)
+            } label: {
+                Image(systemName: "arrow.right")
+            }
+            .buttonStyle(.borderless)
+            .disabled(selectedIndex == nil || selectedIndex == group.apps.count - 1)
+            .help("Move selected app later in the cycle")
+            .accessibilityLabel("Move selected app later in the cycle")
+
+            Button(role: .destructive) {
+                removeSelectedApp(from: group)
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .disabled(selectedIndex == nil)
+            .help("Remove selected app from the group")
+            .accessibilityLabel("Remove selected app from the group")
+        }
+        .padding(.top, 4)
     }
 
     private func runningAppCandidates(for group: AppGroup) -> [AppItem] {

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -9,6 +9,7 @@ import KeyboardShortcuts
 /// View for editing a single app group
 struct GroupEditView: View {
     @EnvironmentObject var store: GroupStore
+    @Environment(\.colorScheme) private var colorScheme
     let groupId: UUID
     private let runningAppCandidatesProvider: ([AppItem]) -> [AppItem]
 
@@ -36,7 +37,10 @@ struct GroupEditView: View {
     var body: some View {
         ScrollView {
             content
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(SettingsChromePalette.windowBackground(for: colorScheme))
         .padding()
         .onAppear {
             loadGroupData()
@@ -76,11 +80,11 @@ struct GroupEditView: View {
             VStack(alignment: .leading, spacing: 20) {
                 groupNameSection(for: group)
 
-                Divider()
+                SettingsSectionDivider()
 
                 GroupShortcutEditor(group: group, groupId: groupId)
 
-                Divider()
+                SettingsSectionDivider()
 
                 appsSection(for: group)
 
@@ -107,7 +111,14 @@ struct GroupEditView: View {
                 .padding(.horizontal, 8)
                 .background(
                     RoundedRectangle(cornerRadius: 6)
-                        .fill(isHovering ? Color.secondary.opacity(0.1) : Color.clear)
+                        .fill((isHovering || isNameFocused) ? SettingsChromePalette.inlineFill(for: colorScheme) : Color.clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(
+                            ((isHovering || isNameFocused) && colorScheme == .dark) ? SettingsChromePalette.panelBorder(for: colorScheme) : Color.clear,
+                            lineWidth: 1
+                        )
                 )
                 .onHover { hovering in
                     isHovering = hovering
@@ -183,8 +194,15 @@ struct GroupEditView: View {
                         runningAppsOptionCard(quickAddCandidates)
                             .frame(minWidth: 360, maxWidth: .infinity, alignment: .leading)
 
-                        Divider()
-                            .padding(.vertical, 4)
+                        if colorScheme == .dark {
+                            Rectangle()
+                                .fill(SettingsChromePalette.panelBorder(for: colorScheme))
+                                .frame(width: 1)
+                                .padding(.vertical, 4)
+                        } else {
+                            Divider()
+                                .padding(.vertical, 4)
+                        }
 
                         browseAppsOptionCard(for: group)
                             .frame(minWidth: 220, idealWidth: 240, maxWidth: 280, alignment: .leading)
@@ -202,11 +220,11 @@ struct GroupEditView: View {
         .padding(14)
         .background(
             RoundedRectangle(cornerRadius: 14)
-                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.75))
+                .fill(SettingsChromePalette.panelBackground(for: colorScheme))
         )
         .overlay(
             RoundedRectangle(cornerRadius: 14)
-                .stroke(Color.secondary.opacity(0.08), lineWidth: 1)
+                .stroke(SettingsChromePalette.panelBorder(for: colorScheme), lineWidth: 1)
         )
     }
 
@@ -287,6 +305,7 @@ private struct RunningAppQuickAddButton: View {
     let onAdd: () -> Void
 
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
+    @Environment(\.colorScheme) private var colorScheme
     @State private var isHovered = false
 
     var body: some View {
@@ -314,11 +333,11 @@ private struct RunningAppQuickAddButton: View {
             .padding(.horizontal, 4)
             .background(
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(isHovered ? Color.accentColor.opacity(0.10) : Color.clear)
+                    .fill(isHovered ? SettingsChromePalette.neutralHoverFill(for: colorScheme) : Color.clear)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 10)
-                    .stroke(isHovered ? Color.accentColor.opacity(0.28) : Color.clear, lineWidth: 1)
+                    .stroke(isHovered ? SettingsChromePalette.neutralHoverBorder(for: colorScheme) : Color.clear, lineWidth: 1)
             )
         }
         .buttonStyle(.plain)
@@ -385,7 +404,7 @@ private struct GroupShortcutEditor: View {
                 }
             }
 
-            Divider()
+            SettingsSectionDivider()
 
             HStack {
                 Text("Cycling Mode".localized(language: selectedLanguage))

--- a/ShortcutCycle/ShortcutCycle/Views/GroupListView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupListView.swift
@@ -14,10 +14,28 @@ struct GroupListView: View {
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     @FocusState private var isInputFocused: Bool
 
+    /// A deferred-write binding for the List selection.
+    ///
+    /// NSTableView (backing List) can fire its selection-changed callback synchronously
+    /// during its layout pass when .scrollContentBackground(.hidden) causes a re-layout.
+    /// Writing to a @Published property during SwiftUI's render/commit phase fires
+    /// objectWillChange synchronously, which AttributeGraph detects as a cycle. Deferring
+    /// the write via Task breaks the synchronous path while preserving selection behavior.
+    private var selectedGroupIdBinding: Binding<UUID?> {
+        Binding(
+            get: { store.selectedGroupId },
+            set: { newValue in
+                Task { @MainActor in
+                    store.selectedGroupId = newValue
+                }
+            }
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Groups list
-            List(selection: $store.selectedGroupId) {
+            List(selection: selectedGroupIdBinding) {
                 ForEach(store.groups) { group in
                     GroupRowView(group: group)
                         .tag(group.id)

--- a/ShortcutCycle/ShortcutCycle/Views/GroupListView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupListView.swift
@@ -7,6 +7,7 @@ import KeyboardShortcuts
 /// Sidebar view showing the list of all groups
 struct GroupListView: View {
     @EnvironmentObject var store: GroupStore
+    @Environment(\.colorScheme) private var colorScheme
     @State private var newGroupName = ""
     @State private var groupToRename: AppGroup?
     @State private var renameText = ""
@@ -36,6 +37,8 @@ struct GroupListView: View {
                 }
             }
             .listStyle(.sidebar)
+            .scrollContentBackground(colorScheme == .dark ? .hidden : .automatic)
+            .background(SettingsChromePalette.sidebarBackground(for: colorScheme))
             .id(selectedLanguage) // Force redraw of list and context menus when language changes
 
             Divider()
@@ -79,6 +82,7 @@ struct GroupListView: View {
                 .buttonStyle(.plain)
             }
         }
+        .background(SettingsChromePalette.sidebarBackground(for: colorScheme))
         .alert("Rename Group", isPresented: Binding(
             get: { groupToRename != nil },
             set: { if !$0 { groupToRename = nil } }
@@ -114,6 +118,7 @@ struct GroupListView: View {
 struct GroupRowView: View {
     let group: AppGroup
     @EnvironmentObject var store: GroupStore
+    @Environment(\.colorScheme) private var colorScheme
     @State private var showDeleteConfirmation = false
     @State private var isHovering = false
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
@@ -149,7 +154,7 @@ struct GroupRowView: View {
                         .foregroundColor(.secondary)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
-                        .background(Color.gray.opacity(0.2))
+                        .background(SettingsChromePalette.chipFill(for: colorScheme))
                         .cornerRadius(4)
                         .lineLimit(1)
                 } else {
@@ -165,11 +170,11 @@ struct GroupRowView: View {
             
             // App count badge
             Text("\(group.apps.count)")
-                .font(.caption)
-                .foregroundColor(.white)
+                .font(colorScheme == .dark ? .caption.weight(.semibold) : .caption)
+                .foregroundStyle(colorScheme == .dark ? AnyShapeStyle(.secondary) : AnyShapeStyle(.white))
                 .padding(.horizontal, 6)
                 .padding(.vertical, 2)
-                .background(Capsule().fill(Color.gray.opacity(0.5)))
+                .background(Capsule().fill(SettingsChromePalette.badgeFill(for: colorScheme)))
                 .layoutPriority(1)
             
             // Delete button (Visible only on hover)

--- a/ShortcutCycle/ShortcutCycle/Views/MainView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/MainView.swift
@@ -72,6 +72,8 @@ struct MainView: View {
         } message: {
             Text("This action cannot be undone.".localized(language: selectedLanguage))
         }
+        .toolbarBackground(Color(nsColor: .windowBackgroundColor), for: .windowToolbar)
+        .toolbarBackground(.visible, for: .windowToolbar)
         .preferredColorScheme(appTheme.colorScheme)
         .frame(minWidth: 720, minHeight: 460)
         .environment(\.locale, LanguageManager.shared.locale)

--- a/ShortcutCycle/ShortcutCycle/Views/MainView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/MainView.swift
@@ -11,7 +11,6 @@ import ShortcutCycleCore
 
 struct MainView: View {
     @EnvironmentObject var store: GroupStore
-    @Environment(\.colorScheme) private var colorScheme
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     @AppStorage("appTheme") private var appTheme: AppTheme = .system
     @EnvironmentObject var localeObserver: LocaleObserver
@@ -43,7 +42,6 @@ struct MainView: View {
             }
         }
         .focusedSceneValue(\.selectedTab, $selectedTab)
-        .background(SettingsChromePalette.windowBackground(for: colorScheme))
         .background(SettingsWindowObserver())
         .onAppear {
             if let pendingTab = ShortcutCycleURLNavigationState.consumePendingSettingsTab() {

--- a/ShortcutCycle/ShortcutCycle/Views/MainView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/MainView.swift
@@ -11,6 +11,7 @@ import ShortcutCycleCore
 
 struct MainView: View {
     @EnvironmentObject var store: GroupStore
+    @Environment(\.colorScheme) private var colorScheme
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     @AppStorage("appTheme") private var appTheme: AppTheme = .system
     @EnvironmentObject var localeObserver: LocaleObserver
@@ -42,6 +43,7 @@ struct MainView: View {
             }
         }
         .focusedSceneValue(\.selectedTab, $selectedTab)
+        .background(SettingsChromePalette.windowBackground(for: colorScheme))
         .background(SettingsWindowObserver())
         .onAppear {
             if let pendingTab = ShortcutCycleURLNavigationState.consumePendingSettingsTab() {

--- a/ShortcutCycle/ShortcutCycle/Views/MenuBarView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/MenuBarView.swift
@@ -15,6 +15,7 @@ struct MenuBarView: View {
     var selectedLanguage: String = "system"
     
     @State private var listHeight: CGFloat = 0
+    @State private var runningBundleIDs = Set<String>()
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -39,7 +40,7 @@ struct MenuBarView: View {
                             .padding()
                     } else {
                         ForEach(store.groups) { group in
-                            MenuBarGroupRow(group: group)
+                            MenuBarGroupRow(group: group, runningBundleIDs: runningBundleIDs)
                         }
                     }
                 }
@@ -117,6 +118,24 @@ struct MenuBarView: View {
         .background(VisualEffectView(material: .popover, blendingMode: .behindWindow))
         .background(WindowAppearanceApplier(colorScheme: appTheme.colorScheme))
         .preferredColorScheme(appTheme.colorScheme)
+        .onAppear {
+            refreshRunningBundleIDs()
+        }
+        .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didLaunchApplicationNotification)) { _ in
+            refreshRunningBundleIDs()
+        }
+        .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didTerminateApplicationNotification)) { _ in
+            refreshRunningBundleIDs()
+        }
+    }
+
+    private func refreshRunningBundleIDs() {
+        runningBundleIDs = Set(
+            NSWorkspace.shared.runningApplications.compactMap { app in
+                guard app.activationPolicy == .regular else { return nil }
+                return app.bundleIdentifier
+            }
+        )
     }
 }
 
@@ -151,6 +170,7 @@ struct MenuBarButton: View {
 /// A single group row in the menu bar view
 struct MenuBarGroupRow: View {
     let group: AppGroup
+    let runningBundleIDs: Set<String>
     @EnvironmentObject var store: GroupStore
     @State private var isHovering = false
     
@@ -185,9 +205,7 @@ struct MenuBarGroupRow: View {
                     .cornerRadius(4)
             }
             
-            // Show running app count
-            let runningCount = countRunningApps(in: group)
-            if runningCount > 0 {
+            if hasRunningApp {
                 Circle()
                     .fill(group.isEnabled ? (isHovering ? .white : Color.green) : Color.gray)
                     .frame(width: 6, height: 6)
@@ -201,15 +219,9 @@ struct MenuBarGroupRow: View {
             isHovering = hovering
         }
     }
-    
-    private func countRunningApps(in group: AppGroup) -> Int {
-        let runningApps = NSWorkspace.shared.runningApplications
-        let groupBundleIds = Set(group.apps.map { $0.bundleIdentifier })
-        
-        return runningApps.filter { app in
-            guard let bundleId = app.bundleIdentifier else { return false }
-            return groupBundleIds.contains(bundleId) && app.activationPolicy == .regular
-        }.count
+
+    private var hasRunningApp: Bool {
+        group.apps.contains { runningBundleIDs.contains($0.bundleIdentifier) }
     }
 }
 

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/BackupBrowserView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/BackupBrowserView.swift
@@ -200,7 +200,7 @@ struct BackupBrowserView: View {
             .listStyle(.sidebar)
             .focused($isSidebarFocused)
 
-            Text("⌥-click to compare with a different backup".localized(language: selectedLanguage))
+            Text("Comparison defaults to the next older backup. Use Changes from to pick a different one.")
                 .font(.caption2)
                 .foregroundColor(.secondary)
                 .padding(.horizontal, 8)

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/BackupBrowserView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/BackupBrowserView.swift
@@ -200,7 +200,7 @@ struct BackupBrowserView: View {
             .listStyle(.sidebar)
             .focused($isSidebarFocused)
 
-            Text("Comparison defaults to the next older backup. Use Changes from to pick a different one.")
+            Text("Comparison defaults to the next older backup. Use Changes from to pick a different one.".localized(language: selectedLanguage))
                 .font(.caption2)
                 .foregroundColor(.secondary)
                 .padding(.horizontal, 8)

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
@@ -121,7 +121,6 @@ struct GeneralSettingsView: View {
                             .foregroundStyle(.tertiary)
                     }
                 }
-                .focusable()
                 .popover(isPresented: $showShortcutReferencePopover, arrowEdge: .bottom) {
                     KeyboardShortcutReferencePopover(selectedLanguage: selectedLanguage)
                 }
@@ -131,7 +130,6 @@ struct GeneralSettingsView: View {
                         WelcomeExperiencePolicy.prepareReplay()
                         ShortcutCycleURLRouter.openSettingsFromOutsideView(tab: .groups)
                     }
-                    .focusable()
                 }
 
             } header: {
@@ -148,12 +146,10 @@ struct GeneralSettingsView: View {
                         Button("Export Settings...".localized(language: selectedLanguage)) {
                             exportSettings()
                         }
-                        .focusable()
 
                         Button("Import Settings...".localized(language: selectedLanguage)) {
                             importSettings()
                         }
-                        .focusable()
                     }
                     Text("Save to or load from a JSON file.".localized(language: selectedLanguage))
                         .font(.caption2)
@@ -170,12 +166,10 @@ struct GeneralSettingsView: View {
                         Button("Copy to Clipboard".localized(language: selectedLanguage)) {
                             copySettingsToClipboard()
                         }
-                        .focusable()
 
                         Button("Paste from Clipboard".localized(language: selectedLanguage)) {
                             pasteSettingsFromClipboard()
                         }
-                        .focusable()
                     }
                     Text("Use Universal Clipboard to sync between Macs.".localized(language: selectedLanguage))
                         .font(.caption2)
@@ -191,11 +185,9 @@ struct GeneralSettingsView: View {
                         Button("View Automatic Backups...".localized(language: selectedLanguage)) {
                             showBackupBrowser = true
                         }
-                        .focusable()
                         Button("Back Up Now".localized(language: selectedLanguage)) {
                             performManualBackup()
                         }
-                        .focusable()
                     }
                     if let feedback = manualBackupFeedback {
                         Text(feedback)
@@ -407,11 +399,11 @@ private struct KeyboardShortcutReferencePopover: View {
             ("General".localized(language: selectedLanguage), ["⌘2"]),
             ("Add Group".localized(language: selectedLanguage), ["⌘N"]),
             ("Delete Group".localized(language: selectedLanguage), ["⌘⌫"]),
-            ("Toggle Sidebar", ["⌃⌘S"]),
-            ("Previous Group", ["⌘↑", "⌘[", "⌘K"]),
-            ("Next Group", ["⌘↓", "⌘]", "⌘J"]),
-            ("Move Group Up", ["⌥⌘↑"]),
-            ("Move Group Down", ["⌥⌘↓"])
+            ("Toggle Sidebar".localized(language: selectedLanguage), ["⌃⌘S"]),
+            ("Previous Group".localized(language: selectedLanguage), ["⌘↑", "⌘[", "⌘K"]),
+            ("Next Group".localized(language: selectedLanguage), ["⌘↓", "⌘]", "⌘J"]),
+            ("Move Group Up".localized(language: selectedLanguage), ["⌥⌘↑"]),
+            ("Move Group Down".localized(language: selectedLanguage), ["⌥⌘↓"])
         ]
     }
 
@@ -428,11 +420,12 @@ private struct KeyboardShortcutReferencePopover: View {
                         KeyboardShortcutReferenceRow(title: item.title, shortcuts: item.shortcuts)
                     }
                 }
+                .padding(.trailing, 14)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .padding(16)
-        .frame(width: 360, height: 300)
+        .frame(width: 380, height: 300)
     }
 }
 

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import KeyboardShortcuts
 import UniformTypeIdentifiers
 #if canImport(ShortcutCycleCore)
 import ShortcutCycleCore
@@ -27,6 +26,7 @@ struct GeneralSettingsView: View {
     // Backup browser state
     @State private var showBackupBrowser = false
     @State private var manualBackupFeedback: String?
+    @State private var showShortcutReferencePopover = false
 
     // Clipboard state
     @State private var showClipboardImportConfirmation = false
@@ -88,68 +88,6 @@ struct GeneralSettingsView: View {
             }
             
             Section {
-                HStack {
-                    Text("Settings Window".localized(language: selectedLanguage))
-                    Spacer()
-                    KeyboardShortcuts.Recorder(for: .toggleSettings)
-                }
-
-                Divider()
-
-                KeyboardShortcutReferenceRow(
-                    title: "Settings...".localized(language: selectedLanguage),
-                    shortcuts: ["⌘,"]
-                )
-
-                KeyboardShortcutReferenceRow(
-                    title: "Groups".localized(language: selectedLanguage),
-                    shortcuts: ["⌘1"]
-                )
-
-                KeyboardShortcutReferenceRow(
-                    title: "General".localized(language: selectedLanguage),
-                    shortcuts: ["⌘2"]
-                )
-
-                KeyboardShortcutReferenceRow(
-                    title: "Add Group".localized(language: selectedLanguage),
-                    shortcuts: ["⌘N"]
-                )
-
-                KeyboardShortcutReferenceRow(
-                    title: "Delete Group".localized(language: selectedLanguage),
-                    shortcuts: ["⌘⌫"]
-                )
-
-                KeyboardShortcutReferenceRow(
-                    title: "Toggle Sidebar",
-                    shortcuts: ["⌃⌘S"]
-                )
-
-                KeyboardShortcutReferenceRow(
-                    title: "Previous Group",
-                    shortcuts: ["⌘↑", "⌘[", "⌘K"]
-                )
-
-                KeyboardShortcutReferenceRow(
-                    title: "Next Group",
-                    shortcuts: ["⌘↓", "⌘]", "⌘J"]
-                )
-
-                KeyboardShortcutReferenceRow(
-                    title: "Move Group Up",
-                    shortcuts: ["⌥⌘↑"]
-                )
-
-                KeyboardShortcutReferenceRow(
-                    title: "Move Group Down",
-                    shortcuts: ["⌥⌘↓"]
-                )
-            } header: {
-                Text("Shortcuts".localized(language: selectedLanguage))
-            }
-            
-            Section {
                 Toggle("Open at Login".localized(language: selectedLanguage), isOn: $launchAtLogin.isEnabled)
                     .toggleStyle(.switch)
 
@@ -173,11 +111,27 @@ struct GeneralSettingsView: View {
                 }
                 .pickerStyle(.menu)
 
+                Button {
+                    showShortcutReferencePopover = true
+                } label: {
+                    HStack {
+                        Label("Shortcuts".localized(language: selectedLanguage), systemImage: "keyboard")
+                        Spacer()
+                        Image(systemName: "chevron.up.chevron.down")
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .focusable()
+                .popover(isPresented: $showShortcutReferencePopover, arrowEdge: .bottom) {
+                    KeyboardShortcutReferencePopover(selectedLanguage: selectedLanguage)
+                }
+
                 if WelcomeExperiencePolicy.shouldShowReplayControl(hasDismissedWelcome: hasDismissedWelcome) {
                     Button("Show welcome again".localized(language: selectedLanguage)) {
                         WelcomeExperiencePolicy.prepareReplay()
                         ShortcutCycleURLRouter.openSettingsFromOutsideView(tab: .groups)
                     }
+                    .focusable()
                 }
 
             } header: {
@@ -194,10 +148,12 @@ struct GeneralSettingsView: View {
                         Button("Export Settings...".localized(language: selectedLanguage)) {
                             exportSettings()
                         }
+                        .focusable()
 
                         Button("Import Settings...".localized(language: selectedLanguage)) {
                             importSettings()
                         }
+                        .focusable()
                     }
                     Text("Save to or load from a JSON file.".localized(language: selectedLanguage))
                         .font(.caption2)
@@ -214,10 +170,12 @@ struct GeneralSettingsView: View {
                         Button("Copy to Clipboard".localized(language: selectedLanguage)) {
                             copySettingsToClipboard()
                         }
+                        .focusable()
 
                         Button("Paste from Clipboard".localized(language: selectedLanguage)) {
                             pasteSettingsFromClipboard()
                         }
+                        .focusable()
                     }
                     Text("Use Universal Clipboard to sync between Macs.".localized(language: selectedLanguage))
                         .font(.caption2)
@@ -233,9 +191,11 @@ struct GeneralSettingsView: View {
                         Button("View Automatic Backups...".localized(language: selectedLanguage)) {
                             showBackupBrowser = true
                         }
+                        .focusable()
                         Button("Back Up Now".localized(language: selectedLanguage)) {
                             performManualBackup()
                         }
+                        .focusable()
                     }
                     if let feedback = manualBackupFeedback {
                         Text(feedback)
@@ -434,6 +394,45 @@ struct GeneralSettingsView: View {
         store.applyImport(export)
         showClipboardImportSuccess = true
         pendingClipboardExport = nil
+    }
+}
+
+private struct KeyboardShortcutReferencePopover: View {
+    let selectedLanguage: String
+
+    private var shortcutReferences: [(title: String, shortcuts: [String])] {
+        [
+            ("Settings...".localized(language: selectedLanguage), ["⌘,"]),
+            ("Groups".localized(language: selectedLanguage), ["⌘1"]),
+            ("General".localized(language: selectedLanguage), ["⌘2"]),
+            ("Add Group".localized(language: selectedLanguage), ["⌘N"]),
+            ("Delete Group".localized(language: selectedLanguage), ["⌘⌫"]),
+            ("Toggle Sidebar", ["⌃⌘S"]),
+            ("Previous Group", ["⌘↑", "⌘[", "⌘K"]),
+            ("Next Group", ["⌘↓", "⌘]", "⌘J"]),
+            ("Move Group Up", ["⌥⌘↑"]),
+            ("Move Group Down", ["⌥⌘↓"])
+        ]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Shortcuts".localized(language: selectedLanguage))
+                .font(.headline)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(Array(shortcutReferences.enumerated()), id: \.offset) { _, item in
+                        KeyboardShortcutReferenceRow(title: item.title, shortcuts: item.shortcuts)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(16)
+        .frame(width: 360, height: 300)
     }
 }
 

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
@@ -87,17 +87,67 @@ struct GeneralSettingsView: View {
                 Text("The HUD appears briefly when you cycle through applications in a group.".localized(language: selectedLanguage))
             }
             
-            #if DEBUG
             Section {
                 HStack {
                     Text("Settings Window".localized(language: selectedLanguage))
                     Spacer()
                     KeyboardShortcuts.Recorder(for: .toggleSettings)
                 }
+
+                Divider()
+
+                KeyboardShortcutReferenceRow(
+                    title: "Settings...".localized(language: selectedLanguage),
+                    shortcuts: ["⌘,"]
+                )
+
+                KeyboardShortcutReferenceRow(
+                    title: "Groups".localized(language: selectedLanguage),
+                    shortcuts: ["⌘1"]
+                )
+
+                KeyboardShortcutReferenceRow(
+                    title: "General".localized(language: selectedLanguage),
+                    shortcuts: ["⌘2"]
+                )
+
+                KeyboardShortcutReferenceRow(
+                    title: "Add Group".localized(language: selectedLanguage),
+                    shortcuts: ["⌘N"]
+                )
+
+                KeyboardShortcutReferenceRow(
+                    title: "Delete Group".localized(language: selectedLanguage),
+                    shortcuts: ["⌘⌫"]
+                )
+
+                KeyboardShortcutReferenceRow(
+                    title: "Toggle Sidebar",
+                    shortcuts: ["⌃⌘S"]
+                )
+
+                KeyboardShortcutReferenceRow(
+                    title: "Previous Group",
+                    shortcuts: ["⌘↑", "⌘[", "⌘K"]
+                )
+
+                KeyboardShortcutReferenceRow(
+                    title: "Next Group",
+                    shortcuts: ["⌘↓", "⌘]", "⌘J"]
+                )
+
+                KeyboardShortcutReferenceRow(
+                    title: "Move Group Up",
+                    shortcuts: ["⌥⌘↑"]
+                )
+
+                KeyboardShortcutReferenceRow(
+                    title: "Move Group Down",
+                    shortcuts: ["⌥⌘↓"]
+                )
             } header: {
                 Text("Shortcuts".localized(language: selectedLanguage))
             }
-            #endif
             
             Section {
                 Toggle("Open at Login".localized(language: selectedLanguage), isOn: $launchAtLogin.isEnabled)
@@ -384,5 +434,30 @@ struct GeneralSettingsView: View {
         store.applyImport(export)
         showClipboardImportSuccess = true
         pendingClipboardExport = nil
+    }
+}
+
+private struct KeyboardShortcutReferenceRow: View {
+    let title: String
+    let shortcuts: [String]
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(title)
+            Spacer(minLength: 12)
+            HStack(spacing: 6) {
+                ForEach(shortcuts, id: \.self) { shortcut in
+                    Text(shortcut)
+                        .font(.caption.monospaced())
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(Color(nsColor: .controlBackgroundColor))
+                        )
+                }
+            }
+            .foregroundStyle(.secondary)
+        }
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
@@ -179,6 +179,7 @@ struct GeneralSettingsView: View {
                     get: { UserDefaults.standard.string(forKey: "selectedLanguage") ?? "system" },
                     set: { newValue in
                         UserDefaults.standard.set(newValue, forKey: "selectedLanguage")
+                        LanguageManager.shared.syncAppleLanguages(for: newValue)
                     }
                 )) {
                     Text("\("System Default".localized(language: "system")) (\(LanguageManager.shared.supportedLanguages.first { $0.code == LanguageManager.shared.systemLanguageCode }?.name ?? "English"))").tag("system")

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
@@ -417,7 +417,11 @@ private struct KeyboardShortcutReferencePopover: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 10) {
                     ForEach(Array(shortcutReferences.enumerated()), id: \.offset) { _, item in
-                        KeyboardShortcutReferenceRow(title: item.title, shortcuts: item.shortcuts)
+                        KeyboardShortcutReferenceRow(
+                            title: item.title,
+                            shortcuts: item.shortcuts,
+                            selectedLanguage: selectedLanguage
+                        )
                     }
                 }
                 .padding(.trailing, 22)
@@ -432,14 +436,21 @@ private struct KeyboardShortcutReferencePopover: View {
 private struct KeyboardShortcutReferenceRow: View {
     let title: String
     let shortcuts: [String]
+    let selectedLanguage: String
 
     var body: some View {
         HStack(alignment: .center, spacing: 16) {
             Text(title)
             Spacer(minLength: 12)
             HStack(spacing: 6) {
-                ForEach(shortcuts, id: \.self) { shortcut in
+                ForEach(Array(shortcuts.enumerated()), id: \.offset) { index, shortcut in
                     KeyboardShortcutBadge(shortcut: shortcut)
+
+                    if index < shortcuts.count - 1 {
+                        Text("or".localized(language: selectedLanguage))
+                            .font(.caption2.weight(.medium))
+                            .foregroundStyle(.tertiary)
+                    }
                 }
             }
             .fixedSize(horizontal: true, vertical: false)

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
@@ -420,12 +420,12 @@ private struct KeyboardShortcutReferencePopover: View {
                         KeyboardShortcutReferenceRow(title: item.title, shortcuts: item.shortcuts)
                     }
                 }
-                .padding(.trailing, 14)
+                .padding(.trailing, 22)
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .padding(16)
-        .frame(width: 380, height: 300)
+        .frame(width: 420, height: 300)
     }
 }
 
@@ -434,22 +434,47 @@ private struct KeyboardShortcutReferenceRow: View {
     let shortcuts: [String]
 
     var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
+        HStack(alignment: .center, spacing: 16) {
             Text(title)
             Spacer(minLength: 12)
             HStack(spacing: 6) {
                 ForEach(shortcuts, id: \.self) { shortcut in
-                    Text(shortcut)
-                        .font(.caption.monospaced())
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .fill(Color(nsColor: .controlBackgroundColor))
-                        )
+                    KeyboardShortcutBadge(shortcut: shortcut)
                 }
             }
-            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: true, vertical: false)
         }
+    }
+}
+
+enum KeyboardShortcutGlyphLayout {
+    static func symbols(in shortcut: String) -> [String] {
+        shortcut.map(String.init)
+    }
+}
+
+private struct KeyboardShortcutBadge: View {
+    let shortcut: String
+
+    private var symbols: [String] {
+        KeyboardShortcutGlyphLayout.symbols(in: shortcut)
+    }
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(Array(symbols.enumerated()), id: \.offset) { _, symbol in
+                Text(symbol)
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .lineLimit(1)
+                    .fixedSize()
+            }
+        }
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
@@ -6,6 +6,7 @@ import ShortcutCycleCore
 
 struct GeneralSettingsView: View {
     @EnvironmentObject var store: GroupStore
+    @Environment(\.colorScheme) private var colorScheme
     @AppStorage("showHUD") private var showHUD = true
     @AppStorage("showShortcutInHUD") private var showShortcutInHUD = true
     @AppStorage("appTheme") private var appTheme: AppTheme = .system
@@ -35,176 +36,9 @@ struct GeneralSettingsView: View {
     @State private var clipboardErrorMessage = ""
     @State private var clipboardImportSummary = ""
     @State private var pendingClipboardExport: SettingsExport?
-    
+
     var body: some View {
-        Form {
-            Section {
-                // HUD Preview
-                VStack(alignment: .center) {
-                    HUDPreviewView(showShortcut: showShortcutInHUD, selectedLanguage: selectedLanguage)
-                        .frame(height: 160)
-                        .frame(maxWidth: .infinity)
-                        .background(Color.black.opacity(0.05))
-                        .cornerRadius(8)
-                        .opacity(showHUD ? 1.0 : 0.5) // Dim when disabled
-                        .grayscale(showHUD ? 0.0 : 1.0) // Grayscale when disabled
-                        .saturation(showHUD ? 1.0 : 0.0)
-                        .overlay {
-                            if !showHUD {
-                                // optional: "Disabled" label overlay
-                                Text("HUD Disabled".localized(language: selectedLanguage))
-                                    .font(.headline)
-                                    .foregroundColor(.secondary)
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 6)
-                                    .background(.regularMaterial)
-                                    .cornerRadius(8)
-                            }
-                        }
-                        .padding(.bottom, 8)
-                    
-                    Text("Preview of the Heads-Up Display".localized(language: selectedLanguage))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                .listRowInsets(EdgeInsets())
-                .padding()
-                
-                Toggle("Show HUD when switching".localized(language: selectedLanguage), isOn: $showHUD)
-                
-                if showHUD {
-                    Toggle("Show shortcut in HUD".localized(language: selectedLanguage), isOn: $showShortcutInHUD)
-                        .padding(.leading)
-                    
-                    Text("Displays the keyboard shortcut used to trigger the switch.".localized(language: selectedLanguage))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .padding(.leading)
-                }
-            } header: {
-                Text("HUD Behavior".localized(language: selectedLanguage))
-            } footer: {
-                Text("The HUD appears briefly when you cycle through applications in a group.".localized(language: selectedLanguage))
-            }
-            
-            Section {
-                Toggle("Open at Login".localized(language: selectedLanguage), isOn: $launchAtLogin.isEnabled)
-                    .toggleStyle(.switch)
-
-                Picker("Appearance".localized(language: selectedLanguage), selection: $appTheme) {
-                    ForEach(AppTheme.allCases) { theme in
-                        Text(theme.displayName.localized(language: selectedLanguage)).tag(theme)
-                    }
-                }
-                .pickerStyle(.segmented)
-
-                Picker("Language".localized(language: selectedLanguage), selection: Binding(
-                    get: { UserDefaults.standard.string(forKey: "selectedLanguage") ?? "system" },
-                    set: { newValue in
-                        UserDefaults.standard.set(newValue, forKey: "selectedLanguage")
-                    }
-                )) {
-                    Text("\("System Default".localized(language: "system")) (\(LanguageManager.shared.supportedLanguages.first { $0.code == LanguageManager.shared.systemLanguageCode }?.name ?? "English"))").tag("system")
-                    ForEach(LanguageManager.shared.supportedLanguages, id: \.code) { language in
-                        Text(language.displayName()).tag(language.code)
-                    }
-                }
-                .pickerStyle(.menu)
-
-                Button {
-                    showShortcutReferencePopover = true
-                } label: {
-                    HStack {
-                        Label("Shortcuts".localized(language: selectedLanguage), systemImage: "keyboard")
-                        Spacer()
-                        Image(systemName: "chevron.up.chevron.down")
-                            .foregroundStyle(.tertiary)
-                    }
-                }
-                .popover(isPresented: $showShortcutReferencePopover, arrowEdge: .bottom) {
-                    KeyboardShortcutReferencePopover(selectedLanguage: selectedLanguage)
-                }
-
-                if WelcomeExperiencePolicy.shouldShowReplayControl(hasDismissedWelcome: hasDismissedWelcome) {
-                    Button("Show welcome again".localized(language: selectedLanguage)) {
-                        WelcomeExperiencePolicy.prepareReplay()
-                        ShortcutCycleURLRouter.openSettingsFromOutsideView(tab: .groups)
-                    }
-                }
-
-            } header: {
-                Text("Application".localized(language: selectedLanguage))
-            }
-            
-            Section {
-                // Sub-section 1: File-based backup
-                VStack(alignment: .leading, spacing: 8) {
-                    Label("File Export/Import".localized(language: selectedLanguage), systemImage: "doc.badge.gearshape")
-                        .font(.caption.weight(.medium))
-                        .foregroundColor(.secondary)
-                    HStack {
-                        Button("Export Settings...".localized(language: selectedLanguage)) {
-                            exportSettings()
-                        }
-
-                        Button("Import Settings...".localized(language: selectedLanguage)) {
-                            importSettings()
-                        }
-                    }
-                    Text("Save to or load from a JSON file.".localized(language: selectedLanguage))
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-                
-                
-                // Sub-section 2: Clipboard-based sync
-                VStack(alignment: .leading, spacing: 8) {
-                    Label("Clipboard Sync".localized(language: selectedLanguage), systemImage: "doc.on.clipboard")
-                        .font(.caption.weight(.medium))
-                        .foregroundColor(.secondary)
-                    HStack {
-                        Button("Copy to Clipboard".localized(language: selectedLanguage)) {
-                            copySettingsToClipboard()
-                        }
-
-                        Button("Paste from Clipboard".localized(language: selectedLanguage)) {
-                            pasteSettingsFromClipboard()
-                        }
-                    }
-                    Text("Use Universal Clipboard to sync between Macs.".localized(language: selectedLanguage))
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-
-                // Sub-section 3: Automatic Backups
-                VStack(alignment: .leading, spacing: 8) {
-                    Label("Automatic Backups".localized(language: selectedLanguage), systemImage: "clock.arrow.circlepath")
-                        .font(.caption.weight(.medium))
-                        .foregroundColor(.secondary)
-                    HStack {
-                        Button("View Automatic Backups...".localized(language: selectedLanguage)) {
-                            showBackupBrowser = true
-                        }
-                        Button("Back Up Now".localized(language: selectedLanguage)) {
-                            performManualBackup()
-                        }
-                    }
-                    if let feedback = manualBackupFeedback {
-                        Text(feedback)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .transition(.opacity)
-                            .animation(.easeInOut(duration: 0.3), value: manualBackupFeedback)
-                    }
-                    Text("View and restore from automatic backups.".localized(language: selectedLanguage))
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-            } header: {
-                Text("Backup & Restore".localized(language: selectedLanguage))
-            }
-        }
-        .formStyle(.grouped)
+        content
         .navigationTitle("General".localized(language: selectedLanguage))
         .alert("Export Failed".localized(language: selectedLanguage), isPresented: $showExportError) {
             Button("OK", role: .cancel) {}
@@ -264,6 +98,188 @@ struct GeneralSettingsView: View {
         } message: {
             Text("Your settings have been imported from clipboard.".localized(language: selectedLanguage))
         }
+    }
+
+    private var content: some View {
+        Form {
+            Section {
+                VStack(alignment: .center) {
+                    HUDPreviewView(showShortcut: showShortcutInHUD, selectedLanguage: selectedLanguage)
+                        .frame(height: 160)
+                        .frame(maxWidth: .infinity)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .fill(
+                                    colorScheme == .dark
+                                        ? SettingsChromePalette.panelBackground(for: colorScheme)
+                                        : Color.black.opacity(0.05)
+                                )
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .stroke(
+                                    colorScheme == .dark
+                                        ? SettingsChromePalette.panelBorder(for: colorScheme)
+                                        : Color.clear,
+                                    lineWidth: 1
+                                )
+                        )
+                        .opacity(showHUD ? 1.0 : 0.5)
+                        .grayscale(showHUD ? 0.0 : 1.0)
+                        .saturation(showHUD ? 1.0 : 0.0)
+                        .overlay {
+                            if !showHUD {
+                                Text("HUD Disabled".localized(language: selectedLanguage))
+                                    .font(.headline)
+                                    .foregroundColor(.secondary)
+                                    .padding(.horizontal, 12)
+                                    .padding(.vertical, 6)
+                                    .background(.regularMaterial)
+                                    .cornerRadius(8)
+                            }
+                        }
+                        .padding(.bottom, 8)
+
+                    Text("Preview of the Heads-Up Display".localized(language: selectedLanguage))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .listRowInsets(EdgeInsets())
+                .padding()
+
+                Toggle("Show HUD when switching".localized(language: selectedLanguage), isOn: $showHUD)
+
+                if showHUD {
+                    Toggle("Show shortcut in HUD".localized(language: selectedLanguage), isOn: $showShortcutInHUD)
+                        .padding(.leading)
+
+                    Text("Displays the keyboard shortcut used to trigger the switch.".localized(language: selectedLanguage))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .padding(.leading)
+                }
+            } header: {
+                Text("HUD Behavior".localized(language: selectedLanguage))
+            } footer: {
+                Text("The HUD appears briefly when you cycle through applications in a group.".localized(language: selectedLanguage))
+            }
+
+            Section {
+                Toggle("Open at Login".localized(language: selectedLanguage), isOn: $launchAtLogin.isEnabled)
+                    .toggleStyle(.switch)
+
+                Picker("Appearance".localized(language: selectedLanguage), selection: $appTheme) {
+                    ForEach(AppTheme.allCases) { theme in
+                        Text(theme.displayName.localized(language: selectedLanguage)).tag(theme)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Picker("Language".localized(language: selectedLanguage), selection: Binding(
+                    get: { UserDefaults.standard.string(forKey: "selectedLanguage") ?? "system" },
+                    set: { newValue in
+                        UserDefaults.standard.set(newValue, forKey: "selectedLanguage")
+                    }
+                )) {
+                    Text("\("System Default".localized(language: "system")) (\(LanguageManager.shared.supportedLanguages.first { $0.code == LanguageManager.shared.systemLanguageCode }?.name ?? "English"))").tag("system")
+                    ForEach(LanguageManager.shared.supportedLanguages, id: \.code) { language in
+                        Text(language.displayName()).tag(language.code)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                Button {
+                    showShortcutReferencePopover = true
+                } label: {
+                    HStack {
+                        Label("Shortcuts".localized(language: selectedLanguage), systemImage: "keyboard")
+                        Spacer()
+                        Image(systemName: "chevron.up.chevron.down")
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .popover(isPresented: $showShortcutReferencePopover, arrowEdge: .bottom) {
+                    KeyboardShortcutReferencePopover(selectedLanguage: selectedLanguage)
+                }
+
+                if WelcomeExperiencePolicy.shouldShowReplayControl(hasDismissedWelcome: hasDismissedWelcome) {
+                    Button("Show welcome again".localized(language: selectedLanguage)) {
+                        WelcomeExperiencePolicy.prepareReplay()
+                        ShortcutCycleURLRouter.openSettingsFromOutsideView(tab: .groups)
+                    }
+                }
+
+            } header: {
+                Text("Application".localized(language: selectedLanguage))
+            }
+
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("File Export/Import".localized(language: selectedLanguage), systemImage: "doc.badge.gearshape")
+                        .font(.caption.weight(.medium))
+                        .foregroundColor(.secondary)
+                    HStack {
+                        Button("Export Settings...".localized(language: selectedLanguage)) {
+                            exportSettings()
+                        }
+
+                        Button("Import Settings...".localized(language: selectedLanguage)) {
+                            importSettings()
+                        }
+                    }
+                    Text("Save to or load from a JSON file.".localized(language: selectedLanguage))
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("Clipboard Sync".localized(language: selectedLanguage), systemImage: "doc.on.clipboard")
+                        .font(.caption.weight(.medium))
+                        .foregroundColor(.secondary)
+                    HStack {
+                        Button("Copy to Clipboard".localized(language: selectedLanguage)) {
+                            copySettingsToClipboard()
+                        }
+
+                        Button("Paste from Clipboard".localized(language: selectedLanguage)) {
+                            pasteSettingsFromClipboard()
+                        }
+                    }
+                    Text("Use Universal Clipboard to sync between Macs.".localized(language: selectedLanguage))
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("Automatic Backups".localized(language: selectedLanguage), systemImage: "clock.arrow.circlepath")
+                        .font(.caption.weight(.medium))
+                        .foregroundColor(.secondary)
+                    HStack {
+                        Button("View Automatic Backups...".localized(language: selectedLanguage)) {
+                            showBackupBrowser = true
+                        }
+                        Button("Back Up Now".localized(language: selectedLanguage)) {
+                            performManualBackup()
+                        }
+                    }
+                    if let feedback = manualBackupFeedback {
+                        Text(feedback)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .transition(.opacity)
+                            .animation(.easeInOut(duration: 0.3), value: manualBackupFeedback)
+                    }
+                    Text("View and restore from automatic backups.".localized(language: selectedLanguage))
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+            } header: {
+                Text("Backup & Restore".localized(language: selectedLanguage))
+            }
+        }
+        .formStyle(.grouped)
+        .scrollContentBackground(colorScheme == .dark ? .hidden : .automatic)
+        .background(SettingsChromePalette.windowBackground(for: colorScheme))
     }
 
     // MARK: - Export/Import Actions
@@ -395,6 +411,7 @@ private struct KeyboardShortcutReferencePopover: View {
     private var shortcutReferences: [(title: String, shortcuts: [String])] {
         [
             ("Settings...".localized(language: selectedLanguage), ["⌘,"]),
+            ("Toggle Appearance".localized(language: selectedLanguage), ["⌃⌘A"]),
             ("Groups".localized(language: selectedLanguage), ["⌘1"]),
             ("General".localized(language: selectedLanguage), ["⌘2"]),
             ("Add Group".localized(language: selectedLanguage), ["⌘N"]),

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
@@ -71,7 +71,7 @@ enum SettingsChromePalette {
         }
 
         return colorScheme == .dark
-            ? Color(nsColor: .separatorColor).opacity(0.30)
+            ? Color(nsColor: .quaternaryLabelColor).opacity(0.72)
             : Color.gray.opacity(0.30)
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
@@ -16,19 +16,17 @@ struct GroupSettingsView: View {
                 GroupEditView(groupId: selectedId)
                     .id(selectedId)
             } else {
-                VStack(spacing: 16) {
-                    Image(systemName: "folder")
-                        .font(.system(size: 48))
-                        .foregroundStyle(.secondary)
-
-                    Text("No Group Selected".localized(language: selectedLanguage))
-                        .font(.title2)
-                        .fontWeight(.bold)
-
+                ContentUnavailableView {
+                    Label("No Group Selected".localized(language: selectedLanguage), systemImage: "folder")
+                } description: {
                     Text("Select a group from the sidebar or create a new one.".localized(language: selectedLanguage))
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
+                } actions: {
+                    if store.groups.isEmpty {
+                        Button("Add Group".localized(language: selectedLanguage)) {
+                            store.columnVisibility = .all
+                            store.isAddingGroup = true
+                        }
+                    }
                 }
                 .padding()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
@@ -3,9 +3,98 @@ import SwiftUI
 import ShortcutCycleCore
 #endif
 
+enum SettingsChromePalette {
+    static func windowBackground(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? Color(nsColor: .windowBackgroundColor) : .clear
+    }
+
+    static func sidebarBackground(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? Color(nsColor: .underPageBackgroundColor) : .clear
+    }
+
+    static func panelBackground(for colorScheme: ColorScheme) -> Color {
+        Color(nsColor: .controlBackgroundColor)
+            .opacity(colorScheme == .dark ? 0.88 : 0.75)
+    }
+
+    static func panelBorder(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(nsColor: .separatorColor).opacity(0.18)
+            : Color.secondary.opacity(0.08)
+    }
+
+    static func inlineFill(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(nsColor: .controlBackgroundColor).opacity(0.76)
+            : Color.secondary.opacity(0.10)
+    }
+
+    static func chipFill(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(nsColor: .quaternaryLabelColor).opacity(0.45)
+            : Color.gray.opacity(0.20)
+    }
+
+    static func badgeFill(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(nsColor: .quaternaryLabelColor).opacity(0.40)
+            : Color.gray.opacity(0.50)
+    }
+
+    static func neutralHoverFill(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(nsColor: .controlBackgroundColor).opacity(0.84)
+            : Color.accentColor.opacity(0.10)
+    }
+
+    static func neutralHoverBorder(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color(nsColor: .separatorColor).opacity(0.24)
+            : Color.accentColor.opacity(0.28)
+    }
+
+    static func dropZoneFill(for colorScheme: ColorScheme, targeted: Bool) -> Color {
+        if targeted {
+            return Color.accentColor.opacity(colorScheme == .dark ? 0.12 : 0.10)
+        }
+
+        return colorScheme == .dark
+            ? Color(nsColor: .controlBackgroundColor).opacity(0.30)
+            : .clear
+    }
+
+    static func dropZoneBorder(for colorScheme: ColorScheme, targeted: Bool) -> Color {
+        if targeted {
+            return colorScheme == .dark
+                ? Color.accentColor.opacity(0.58)
+                : .accentColor
+        }
+
+        return colorScheme == .dark
+            ? Color(nsColor: .separatorColor).opacity(0.30)
+            : Color.gray.opacity(0.30)
+    }
+}
+
+struct SettingsSectionDivider: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    @ViewBuilder
+    var body: some View {
+        if colorScheme == .dark {
+            Rectangle()
+                .fill(SettingsChromePalette.panelBorder(for: colorScheme))
+                .frame(height: 1)
+        } else {
+            Divider()
+        }
+    }
+}
+
 struct GroupSettingsView: View {
     @EnvironmentObject var store: GroupStore
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         NavigationSplitView(columnVisibility: $store.columnVisibility) {
@@ -30,8 +119,10 @@ struct GroupSettingsView: View {
                 }
                 .padding()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(SettingsChromePalette.windowBackground(for: colorScheme))
             }
         }
         .navigationTitle("App Groups".localized(language: selectedLanguage))
+        .background(SettingsChromePalette.windowBackground(for: colorScheme))
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
@@ -96,8 +96,27 @@ struct GroupSettingsView: View {
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     @Environment(\.colorScheme) private var colorScheme
 
+    /// A deferred-write binding for columnVisibility.
+    ///
+    /// NSSplitViewController (backing NavigationSplitView) can write to this binding
+    /// synchronously during its layout pass when the Groups tab becomes visible after a
+    /// tab switch. The new .scrollContentBackground(.hidden) on the sidebar List triggers
+    /// that layout re-evaluation. Writing to a @Published property during SwiftUI's
+    /// render/commit phase fires objectWillChange synchronously, which AttributeGraph
+    /// detects as a cycle. Deferring the write via Task breaks the synchronous path.
+    private var columnVisibilityBinding: Binding<NavigationSplitViewVisibility> {
+        Binding(
+            get: { store.columnVisibility },
+            set: { newValue in
+                Task { @MainActor in
+                    store.columnVisibility = newValue
+                }
+            }
+        )
+    }
+
     var body: some View {
-        NavigationSplitView(columnVisibility: $store.columnVisibility) {
+        NavigationSplitView(columnVisibility: columnVisibilityBinding) {
             GroupListView()
                 .frame(minWidth: 220)
         } detail: {

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/HUDPreviewView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/HUDPreviewView.swift
@@ -5,6 +5,36 @@ struct HUDPreviewView: View {
     let showShortcut: Bool
     var selectedLanguage: String = "system"
     @Environment(\.colorScheme) var colorScheme
+
+    private var previewShellFill: Color {
+        colorScheme == .dark
+            ? SettingsChromePalette.panelBackground(for: colorScheme)
+            : Color.white.opacity(0.42)
+    }
+
+    private var previewShellBorder: Color {
+        colorScheme == .dark
+            ? SettingsChromePalette.panelBorder(for: colorScheme)
+            : Color.primary.opacity(0.10)
+    }
+
+    private var selectedTileFill: Color {
+        colorScheme == .dark
+            ? SettingsChromePalette.inlineFill(for: colorScheme)
+            : Color.primary.opacity(0.05)
+    }
+
+    private var selectedTileBorder: Color {
+        colorScheme == .dark
+            ? SettingsChromePalette.panelBorder(for: colorScheme)
+            : Color.primary.opacity(0.10)
+    }
+
+    private var shortcutCapsuleFill: Color {
+        colorScheme == .dark
+            ? SettingsChromePalette.inlineFill(for: colorScheme)
+            : Color.white.opacity(0.72)
+    }
     
     var body: some View {
         VStack(spacing: 16) {
@@ -27,13 +57,18 @@ struct HUDPreviewView: View {
                     .padding(8)
                     .background(
                         RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .fill(Color.primary.opacity(0.05))
+                            .fill(selectedTileFill)
                     )
                     .overlay(
                         RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .stroke(Color.primary.opacity(0.1), lineWidth: 1)
+                            .stroke(selectedTileBorder, lineWidth: 1)
                     )
-                    .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
+                    .shadow(
+                        color: colorScheme == .dark ? .black.opacity(0.18) : .black.opacity(0.10),
+                        radius: colorScheme == .dark ? 10 : 4,
+                        x: 0,
+                        y: colorScheme == .dark ? 6 : 2
+                    )
                     .scaleEffect(1.1)
                 
                 Image(systemName: "envelope.fill")
@@ -47,12 +82,17 @@ struct HUDPreviewView: View {
             .padding(12)
             .background(
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .fill(.ultraThinMaterial)
-                    .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: 4)
+                    .fill(previewShellFill)
+                    .shadow(
+                        color: colorScheme == .dark ? .black.opacity(0.24) : .black.opacity(0.10),
+                        radius: colorScheme == .dark ? 18 : 10,
+                        x: 0,
+                        y: colorScheme == .dark ? 10 : 4
+                    )
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .stroke(Color.primary.opacity(0.1), lineWidth: 1)
+                    .stroke(previewShellBorder, lineWidth: 1)
             )
             
             // App Name Label
@@ -72,7 +112,11 @@ struct HUDPreviewView: View {
             .padding(.vertical, 6)
             .background(
                 Capsule()
-                    .fill(.regularMaterial)
+                    .fill(shortcutCapsuleFill)
+            )
+            .overlay(
+                Capsule()
+                    .stroke(previewShellBorder.opacity(colorScheme == .dark ? 0.85 : 0.65), lineWidth: 1)
             )
         }
     }

--- a/ShortcutCycle/ShortcutCycleTests/GroupEditViewTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/GroupEditViewTests.swift
@@ -9,6 +9,20 @@ import SwiftUI
 @MainActor
 final class GroupEditViewTests: XCTestCase {
 
+    private final class RunningCandidatesProviderSpy {
+        private(set) var calls: [[AppItem]] = []
+
+        func provider(_ apps: [AppItem]) -> [AppItem] {
+            calls.append(apps)
+            return []
+        }
+    }
+
+    private final class ReorderState {
+        var draggingApp: AppItem?
+        var dragPreviewApps: [AppItem]?
+    }
+
     private var userDefaults: UserDefaults!
     private var store: GroupStore!
     private var window: NSWindow?
@@ -66,16 +80,151 @@ final class GroupEditViewTests: XCTestCase {
         XCTAssertFalse(GroupEditView.shouldShowRunningAppQuickAddSection([]))
     }
 
+    func testRunningAppCandidatesDoNotRefreshForPureReorder() throws {
+        let groupId = try XCTUnwrap(store.groups.first?.id)
+        let app1 = AppItem(bundleIdentifier: "com.test.alpha", name: "Alpha")
+        let app2 = AppItem(bundleIdentifier: "com.test.beta", name: "Beta")
+        let app3 = AppItem(bundleIdentifier: "com.test.gamma", name: "Gamma")
+        let providerSpy = RunningCandidatesProviderSpy()
+
+        store.addApp(app1, to: groupId)
+        store.addApp(app2, to: groupId)
+
+        _ = hostGroupEditView(width: 720, runningAppCandidatesProvider: providerSpy.provider)
+        let initialCallCount = providerSpy.calls.count
+        XCTAssertGreaterThanOrEqual(initialCallCount, 1)
+
+        store.replaceApps(in: groupId, with: [app2, app1])
+        drainMainRunLoop()
+        XCTAssertEqual(providerSpy.calls.count, initialCallCount)
+
+        store.addApp(app3, to: groupId)
+        drainMainRunLoop()
+        XCTAssertEqual(providerSpy.calls.count, initialCallCount + 1)
+        XCTAssertEqual(providerSpy.calls.last?.map(\.bundleIdentifier), [app2, app1, app3].map(\.bundleIdentifier))
+    }
+
+    func testAppReorderDelegateBuildsPreviewFromStoreApps() throws {
+        let groupId = try XCTUnwrap(store.groups.first?.id)
+        let app1 = AppItem(bundleIdentifier: "com.test.alpha", name: "Alpha")
+        let app2 = AppItem(bundleIdentifier: "com.test.beta", name: "Beta")
+        let app3 = AppItem(bundleIdentifier: "com.test.gamma", name: "Gamma")
+
+        store.addApp(app1, to: groupId)
+        store.addApp(app2, to: groupId)
+        store.addApp(app3, to: groupId)
+
+        let reorderState = ReorderState()
+        reorderState.draggingApp = app1
+        let delegate = makeReorderDelegate(
+            item: app3,
+            reorderState: reorderState,
+            groupId: groupId
+        )
+
+        delegate.updatePreviewOrder()
+
+        XCTAssertEqual(reorderState.dragPreviewApps, [app2, app3, app1])
+    }
+
+    func testAppReorderDelegateUsesExistingPreviewForSubsequentHover() throws {
+        let groupId = try XCTUnwrap(store.groups.first?.id)
+        let app1 = AppItem(bundleIdentifier: "com.test.alpha", name: "Alpha")
+        let app2 = AppItem(bundleIdentifier: "com.test.beta", name: "Beta")
+        let app3 = AppItem(bundleIdentifier: "com.test.gamma", name: "Gamma")
+
+        store.addApp(app1, to: groupId)
+        store.addApp(app2, to: groupId)
+        store.addApp(app3, to: groupId)
+
+        let reorderState = ReorderState()
+        reorderState.draggingApp = app1
+        reorderState.dragPreviewApps = [app2, app3, app1]
+        let delegate = makeReorderDelegate(
+            item: app2,
+            reorderState: reorderState,
+            groupId: groupId
+        )
+
+        delegate.updatePreviewOrder()
+
+        XCTAssertEqual(reorderState.dragPreviewApps, [app1, app2, app3])
+    }
+
+    func testAppReorderDelegateCommitPersistsPreviewAndClearsDragState() throws {
+        let groupId = try XCTUnwrap(store.groups.first?.id)
+        let app1 = AppItem(bundleIdentifier: "com.test.alpha", name: "Alpha")
+        let app2 = AppItem(bundleIdentifier: "com.test.beta", name: "Beta")
+
+        store.addApp(app1, to: groupId)
+        store.addApp(app2, to: groupId)
+
+        let reorderState = ReorderState()
+        reorderState.draggingApp = app1
+        reorderState.dragPreviewApps = [app2, app1]
+        let delegate = makeReorderDelegate(
+            item: app2,
+            reorderState: reorderState,
+            groupId: groupId
+        )
+
+        delegate.commitPreviewOrder()
+
+        let updatedApps = try XCTUnwrap(store.groups.first(where: { $0.id == groupId })?.apps)
+        XCTAssertEqual(updatedApps, [app2, app1])
+        XCTAssertNil(reorderState.draggingApp)
+        XCTAssertNil(reorderState.dragPreviewApps)
+    }
+
+    func testAppGridItemRendersRegularAndPlaceholderStates() {
+        let app = AppItem(bundleIdentifier: "com.test.grid", name: "Grid App")
+
+        let hostingView = hostView(
+            AnyView(
+                VStack {
+                    AppGridItemView(app: app, isPlaceholder: false, onDelete: {})
+                    AppGridItemView(app: app, isPlaceholder: true, onDelete: {})
+                }
+                .frame(width: 220, height: 260)
+            ),
+            width: 220,
+            height: 260
+        )
+
+        XCTAssertGreaterThan(hostingView.fittingSize.width, 0)
+        XCTAssertGreaterThan(hostingView.fittingSize.height, 0)
+    }
+
     private func hostGroupEditView(
         width: CGFloat,
-        height: CGFloat = 600
+        height: CGFloat = 600,
+        runningAppCandidatesProvider: (([AppItem]) -> [AppItem])? = nil
     ) -> NSHostingView<AnyView> {
         let groupId = try! XCTUnwrap(store.groups.first?.id)
-        let rootView = AnyView(
-            GroupEditView(groupId: groupId)
-                .environmentObject(store)
-                .frame(width: width, height: height)
-        )
+        let rootView: AnyView
+
+        if let runningAppCandidatesProvider {
+            rootView = AnyView(
+                GroupEditView(groupId: groupId, runningAppCandidatesProvider: runningAppCandidatesProvider)
+                    .environmentObject(store)
+                    .frame(width: width, height: height)
+            )
+        } else {
+            rootView = AnyView(
+                GroupEditView(groupId: groupId)
+                    .environmentObject(store)
+                    .frame(width: width, height: height)
+            )
+        }
+
+        return hostView(rootView, width: width, height: height)
+    }
+
+    private func hostView(
+        _ rootView: AnyView,
+        width: CGFloat,
+        height: CGFloat
+    ) -> NSHostingView<AnyView> {
         let hostingView = NSHostingView(rootView: rootView)
         let frame = NSRect(x: 0, y: 0, width: width, height: height)
         window = NSWindow(
@@ -87,8 +236,32 @@ final class GroupEditViewTests: XCTestCase {
         window?.contentView = hostingView
         window?.layoutIfNeeded()
         hostingView.layoutSubtreeIfNeeded()
-        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        drainMainRunLoop()
         return hostingView
+    }
+
+    private func drainMainRunLoop() {
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+    }
+
+    private func makeReorderDelegate(
+        item: AppItem,
+        reorderState: ReorderState,
+        groupId: UUID
+    ) -> AppReorderDelegate {
+        AppReorderDelegate(
+            item: item,
+            draggingApp: Binding(
+                get: { reorderState.draggingApp },
+                set: { reorderState.draggingApp = $0 }
+            ),
+            dragPreviewApps: Binding(
+                get: { reorderState.dragPreviewApps },
+                set: { reorderState.dragPreviewApps = $0 }
+            ),
+            store: store,
+            groupId: groupId
+        )
     }
 
     private func findSubview<ViewType: NSView>(ofType type: ViewType.Type, in root: NSView) -> ViewType? {

--- a/ShortcutCycle/ShortcutCycleTests/GroupStoreTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/GroupStoreTests.swift
@@ -479,6 +479,44 @@ final class GroupStoreTests: XCTestCase {
         XCTAssertTrue(afterFlushStore.groups.contains(where: { $0.name == "Deferred Persist" }))
     }
 
+    func testDebouncedSaveTimerCallbackPersistsChanges() {
+        let suiteName = "TestDebouncedSaveTimer-\(UUID().uuidString)"
+        let isolatedDefaults = UserDefaults(suiteName: suiteName)!
+        isolatedDefaults.removePersistentDomain(forName: suiteName)
+        defer { isolatedDefaults.removePersistentDomain(forName: suiteName) }
+
+        let isolatedFileManager = IsolatedAppSupportFileManager()
+        defer { try? FileManager.default.removeItem(at: isolatedFileManager.appSupportURL) }
+
+        let debouncedStore = GroupStore(
+            userDefaults: isolatedDefaults,
+            backupDebounceInterval: 0,
+            saveDebounceInterval: 0.05,
+            fileManager: isolatedFileManager
+        )
+        debouncedStore.flushPendingSave()
+
+        _ = debouncedStore.addGroup(name: "Timer Persist")
+
+        let beforeTimerStore = GroupStore(
+            userDefaults: isolatedDefaults,
+            backupDebounceInterval: 0,
+            saveDebounceInterval: 0,
+            fileManager: isolatedFileManager
+        )
+        XCTAssertFalse(beforeTimerStore.groups.contains(where: { $0.name == "Timer Persist" }))
+
+        RunLoop.main.run(until: Date().addingTimeInterval(0.2))
+
+        let afterTimerStore = GroupStore(
+            userDefaults: isolatedDefaults,
+            backupDebounceInterval: 0,
+            saveDebounceInterval: 0,
+            fileManager: isolatedFileManager
+        )
+        XCTAssertTrue(afterTimerStore.groups.contains(where: { $0.name == "Timer Persist" }))
+    }
+
     // MARK: - Manual Backup Tests
 
     func testManualBackupSavesFile() {

--- a/ShortcutCycle/ShortcutCycleTests/GroupStoreTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/GroupStoreTests.swift
@@ -254,6 +254,41 @@ final class GroupStoreTests: XCTestCase {
         XCTAssertEqual(group.apps[2].bundleIdentifier, "com.test.1")
     }
 
+    func testReplaceAppsUpdatesOrderAndLastModified() {
+        let groupId = store.groups.first!.id
+        let app1 = AppItem(bundleIdentifier: "com.test.alpha", name: "Alpha")
+        let app2 = AppItem(bundleIdentifier: "com.test.beta", name: "Beta")
+
+        store.addApp(app1, to: groupId)
+        store.addApp(app2, to: groupId)
+
+        let originalGroup = try! XCTUnwrap(store.groups.first(where: { $0.id == groupId }))
+        let originalLastModified = originalGroup.lastModified
+
+        Thread.sleep(forTimeInterval: 0.01)
+        store.replaceApps(in: groupId, with: [app2, app1])
+
+        let updatedGroup = try! XCTUnwrap(store.groups.first(where: { $0.id == groupId }))
+        XCTAssertEqual(updatedGroup.apps, [app2, app1])
+        XCTAssertGreaterThanOrEqual(updatedGroup.lastModified, originalLastModified)
+    }
+
+    func testReplaceAppsNoOpWhenAppsAreUnchanged() {
+        let groupId = store.groups.first!.id
+        let app = AppItem(bundleIdentifier: "com.test.same", name: "Same")
+
+        store.addApp(app, to: groupId)
+
+        let originalGroup = try! XCTUnwrap(store.groups.first(where: { $0.id == groupId }))
+        let originalLastModified = originalGroup.lastModified
+
+        store.replaceApps(in: groupId, with: originalGroup.apps)
+
+        let updatedGroup = try! XCTUnwrap(store.groups.first(where: { $0.id == groupId }))
+        XCTAssertEqual(updatedGroup.apps, originalGroup.apps)
+        XCTAssertEqual(updatedGroup.lastModified, originalLastModified)
+    }
+
     // MARK: - Last Active App
 
     func testUpdateLastActiveApp() {
@@ -404,6 +439,44 @@ final class GroupStoreTests: XCTestCase {
         // Create new store with same defaults
         let store2 = GroupStore(userDefaults: userDefaults)
         XCTAssertTrue(store2.groups.contains(where: { $0.name == "Persistent" }))
+    }
+
+    func testDebouncedSavePersistsOnlyAfterFlushPendingSave() {
+        let suiteName = "TestDebouncedSave-\(UUID().uuidString)"
+        let isolatedDefaults = UserDefaults(suiteName: suiteName)!
+        isolatedDefaults.removePersistentDomain(forName: suiteName)
+        defer { isolatedDefaults.removePersistentDomain(forName: suiteName) }
+
+        let isolatedFileManager = IsolatedAppSupportFileManager()
+        defer { try? FileManager.default.removeItem(at: isolatedFileManager.appSupportURL) }
+
+        let debouncedStore = GroupStore(
+            userDefaults: isolatedDefaults,
+            backupDebounceInterval: 0,
+            saveDebounceInterval: 60,
+            fileManager: isolatedFileManager
+        )
+        debouncedStore.flushPendingSave()
+
+        _ = debouncedStore.addGroup(name: "Deferred Persist")
+
+        let beforeFlushStore = GroupStore(
+            userDefaults: isolatedDefaults,
+            backupDebounceInterval: 0,
+            saveDebounceInterval: 0,
+            fileManager: isolatedFileManager
+        )
+        XCTAssertFalse(beforeFlushStore.groups.contains(where: { $0.name == "Deferred Persist" }))
+
+        debouncedStore.flushPendingSave()
+
+        let afterFlushStore = GroupStore(
+            userDefaults: isolatedDefaults,
+            backupDebounceInterval: 0,
+            saveDebounceInterval: 0,
+            fileManager: isolatedFileManager
+        )
+        XCTAssertTrue(afterFlushStore.groups.contains(where: { $0.name == "Deferred Persist" }))
     }
 
     // MARK: - Manual Backup Tests

--- a/ShortcutCycle/ShortcutCycleTests/LocalizationTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/LocalizationTests.swift
@@ -196,6 +196,7 @@ final class LocalizationTests: XCTestCase {
             "Rename",
             "Delete",
             "Appearance",
+            "Toggle Appearance",
             "Language"
         ]
         

--- a/ShortcutCycle/ShortcutCycleTests/SettingsExportTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/SettingsExportTests.swift
@@ -455,11 +455,13 @@ final class SettingsExportTests: XCTestCase {
         let originalShowHUD = defaults.object(forKey: "showHUD")
         let originalShowShortcut = defaults.object(forKey: "showShortcutInHUD")
         let originalLanguage = defaults.string(forKey: "selectedLanguage")
+        let originalAppleLanguages = defaults.stringArray(forKey: "AppleLanguages")
         let originalTheme = defaults.string(forKey: "appTheme")
         defer {
             if let v = originalShowHUD { defaults.set(v, forKey: "showHUD") } else { defaults.removeObject(forKey: "showHUD") }
             if let v = originalShowShortcut { defaults.set(v, forKey: "showShortcutInHUD") } else { defaults.removeObject(forKey: "showShortcutInHUD") }
             if let v = originalLanguage { defaults.set(v, forKey: "selectedLanguage") } else { defaults.removeObject(forKey: "selectedLanguage") }
+            if let v = originalAppleLanguages { defaults.set(v, forKey: "AppleLanguages") } else { defaults.removeObject(forKey: "AppleLanguages") }
             if let v = originalTheme { defaults.set(v, forKey: "appTheme") } else { defaults.removeObject(forKey: "appTheme") }
         }
 
@@ -469,6 +471,7 @@ final class SettingsExportTests: XCTestCase {
         XCTAssertEqual(defaults.bool(forKey: "showHUD"), false)
         XCTAssertEqual(defaults.bool(forKey: "showShortcutInHUD"), true)
         XCTAssertEqual(defaults.string(forKey: "selectedLanguage"), "ko")
+        XCTAssertEqual(defaults.stringArray(forKey: "AppleLanguages"), ["ko"])
         XCTAssertEqual(defaults.string(forKey: "appTheme"), "light")
     }
 

--- a/ShortcutCycle/ShortcutCycleTests/SettingsExportTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/SettingsExportTests.swift
@@ -475,6 +475,16 @@ final class SettingsExportTests: XCTestCase {
         XCTAssertEqual(defaults.string(forKey: "appTheme"), "light")
     }
 
+    func testAppleLanguagePreferenceSyncFallsBackToLocalePreferredLanguages() {
+        XCTAssertEqual(
+            AppleLanguagePreferenceSync.resolvedPreferredLanguages(
+                from: nil,
+                fallback: ["ja"]
+            ),
+            ["ja"]
+        )
+    }
+
     func testAppSettingsApplyWithNilThemeDoesNotWrite() {
         let defaults = UserDefaults.standard
         let originalTheme = defaults.string(forKey: "appTheme")

--- a/ShortcutCycle/ShortcutCycleTests/SettingsWindowObserverTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/SettingsWindowObserverTests.swift
@@ -16,4 +16,91 @@ final class SettingsWindowObserverTests: XCTestCase {
 
         wait(for: [callbackFired], timeout: 1.0)
     }
+
+    func testShouldRevealFocusForTabKeyInObservedWindow() throws {
+        let coordinator = SettingsWindowObserver.Coordinator()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        coordinator.observe(window: window)
+
+        let tabEvent = try XCTUnwrap(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [],
+                timestamp: 0,
+                windowNumber: window.windowNumber,
+                context: nil,
+                characters: "\t",
+                charactersIgnoringModifiers: "\t",
+                isARepeat: false,
+                keyCode: 48
+            )
+        )
+        let letterEvent = try XCTUnwrap(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: [],
+                timestamp: 0,
+                windowNumber: window.windowNumber,
+                context: nil,
+                characters: "a",
+                charactersIgnoringModifiers: "a",
+                isARepeat: false,
+                keyCode: 0
+            )
+        )
+
+        XCTAssertTrue(coordinator.shouldRevealFocus(for: tabEvent, in: window))
+        XCTAssertFalse(coordinator.shouldRevealFocus(for: letterEvent, in: window))
+    }
+
+    func testRevealFocusedControlScrollsFirstResponderIntoView() {
+        let coordinator = SettingsWindowObserver.Coordinator()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let scrollView = NSScrollView(frame: window.contentView?.bounds ?? .zero)
+        let documentView = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 900))
+        let targetView = RecordingScrollableView(frame: NSRect(x: 20, y: 760, width: 120, height: 28))
+
+        documentView.addSubview(targetView)
+        scrollView.documentView = documentView
+        window.contentView = scrollView
+
+        coordinator.observe(window: window)
+
+        XCTAssertTrue(window.makeFirstResponder(targetView))
+
+        coordinator.revealFocusedControl()
+
+        XCTAssertEqual(targetView.scrolledRect, targetView.bounds.insetBy(dx: 0, dy: -20))
+    }
+
+    func testShortcutGlyphLayoutSplitsModifierSequenceIntoIndividualSymbols() {
+        XCTAssertEqual(KeyboardShortcutGlyphLayout.symbols(in: "⌥⌘↑"), ["⌥", "⌘", "↑"])
+        XCTAssertEqual(KeyboardShortcutGlyphLayout.symbols(in: "⌘,"), ["⌘", ","])
+    }
+}
+
+@MainActor
+private final class RecordingScrollableView: NSView {
+    var scrolledRect: NSRect?
+
+    override var acceptsFirstResponder: Bool {
+        true
+    }
+
+    override func scrollToVisible(_ rect: NSRect) -> Bool {
+        scrolledRect = rect
+        return true
+    }
 }

--- a/ShortcutCycle/ShortcutCycleTests/ShortcutCycleTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/ShortcutCycleTests.swift
@@ -217,6 +217,23 @@ final class ShortcutCycleTests: XCTestCase {
         )
     }
 
+    @MainActor
+    func testSetSettingSelectedLanguageSyncsAppleLanguages() {
+        let defaults = UserDefaults.standard
+        let originalLanguage = defaults.string(forKey: "selectedLanguage")
+        let originalAppleLanguages = defaults.stringArray(forKey: "AppleLanguages")
+        defer {
+            if let v = originalLanguage { defaults.set(v, forKey: "selectedLanguage") } else { defaults.removeObject(forKey: "selectedLanguage") }
+            if let v = originalAppleLanguages { defaults.set(v, forKey: "AppleLanguages") } else { defaults.removeObject(forKey: "AppleLanguages") }
+        }
+
+        let url = URL(string: "shortcutcycle://set-setting?key=selectedlanguage&value=zh-Hant")!
+        ShortcutCycleURLRouter.handle(url)
+
+        XCTAssertEqual(defaults.string(forKey: "selectedLanguage"), "zh-Hant")
+        XCTAssertEqual(defaults.stringArray(forKey: "AppleLanguages"), ["zh-TW"])
+    }
+
     func testParseSetSettingWithTooLongKeyOrValueReturnsNil() {
         let longKey = String(repeating: "k", count: 129)
         let longValue = String(repeating: "v", count: 129)

--- a/ShortcutCycle/ShortcutCycleTests/ShortcutCycleTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/ShortcutCycleTests.swift
@@ -217,6 +217,7 @@ final class ShortcutCycleTests: XCTestCase {
         )
     }
 
+#if !canImport(ShortcutCycleCore)
     @MainActor
     func testSetSettingSelectedLanguageSyncsAppleLanguages() {
         let defaults = UserDefaults.standard
@@ -233,6 +234,7 @@ final class ShortcutCycleTests: XCTestCase {
         XCTAssertEqual(defaults.string(forKey: "selectedLanguage"), "zh-Hant")
         XCTAssertEqual(defaults.stringArray(forKey: "AppleLanguages"), ["zh-TW"])
     }
+#endif
 
     func testParseSetSettingWithTooLongKeyOrValueReturnsNil() {
         let longKey = String(repeating: "k", count: 129)

--- a/ShortcutCycle/ShortcutCycleTests/ShortcutCycleTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/ShortcutCycleTests.swift
@@ -2,6 +2,7 @@ import XCTest
 #if canImport(ShortcutCycleCore)
 @testable import ShortcutCycleCore
 #else
+import AppKit
 @testable import ShortcutCycle
 #endif
 
@@ -194,6 +195,19 @@ final class ShortcutCycleTests: XCTestCase {
         let url = URL(string: "shortcutcycle://set-setting?key=appTheme&value=blue")!
         XCTAssertNil(ShortcutCycleURLParser.parse(url))
     }
+
+#if !canImport(ShortcutCycleCore)
+    func testAppThemeToggleFlipsExplicitThemes() {
+        XCTAssertEqual(AppTheme.light.toggledAppearance(using: .aqua), .dark)
+        XCTAssertEqual(AppTheme.dark.toggledAppearance(using: .darkAqua), .light)
+    }
+
+    func testAppThemeToggleUsesResolvedSystemAppearance() {
+        XCTAssertEqual(AppTheme.system.toggledAppearance(using: .aqua), .dark)
+        XCTAssertEqual(AppTheme.system.toggledAppearance(using: .darkAqua), .light)
+        XCTAssertEqual(AppTheme.system.toggledAppearance(using: nil), .dark)
+    }
+#endif
 
     func testParseSetSettingWithSelectedLanguageValue() {
         let url = URL(string: "shortcutcycle://set-setting?key=selectedlanguage&value=en")!


### PR DESCRIPTION
## Summary
- fix the shortcut-suggestion build issue and polish the setup flow with a clearer empty-state path into creating the first group
- add standard macOS settings discoverability with `Cmd+,`, a shortcuts reference popover in General, and keyboard focus for the primary settings actions that matter most
- keep the group editor keyboard-friendly for core controls like the group name, shortcut recorder, and cycling mode, while restoring the application grid and add-app surface to a cleaner mouse-first design
- smooth app-grid interactions by debouncing group persistence, moving auto-backups off the hot path, skipping running-app recomputation on pure reorder, and using a live drag preview that only commits to storage on drop
- restore more polished app-grid drag feedback with a ghost placeholder in the source slot, and reduce extra settings/menu bar churn while updating the backup-browser guidance to match the real comparison flow

## Why
- the original setup and settings flows still had a few points of first-run friction and poor shortcut discoverability
- pushing the entire app grid into keyboard-only interaction added visual weight without feeling especially natural on macOS
- drag, add, and remove interactions in the app grid were doing too much synchronous persistence work, which made the editor feel sticky during reordering
- the PR had grown beyond pure keyboard accessibility work, so the title and description needed to reflect the final product direction more accurately

## Impact
- makes the setup and settings experience easier to discover and faster to navigate
- keeps keyboard support where it adds the most value without forcing every visual tile into the tab loop
- improves app-grid responsiveness while preserving live reorder feedback and the prettier master-style visuals
- aligns the PR description with the actual shipped behavior on this branch

## Validation
- `xcodebuild -project ShortcutCycle/ShortcutCycle.xcodeproj -scheme ShortcutCycle -configuration Debug -sdk macosx build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project ShortcutCycle/ShortcutCycle.xcodeproj -scheme ShortcutCycle -configuration Debug -sdk macosx CODE_SIGNING_ALLOWED=NO -only-testing:ShortcutCycleTests/GroupStoreTests -only-testing:ShortcutCycleTests/GroupEditViewTests`
- `xcodebuild test -project ShortcutCycle/ShortcutCycle.xcodeproj -scheme ShortcutCycle -destination 'platform=macOS' -only-testing:ShortcutCycleTests/BackupBrowserTests`
- `xcodebuild test -project ShortcutCycle/ShortcutCycle.xcodeproj -scheme ShortcutCycle -destination 'platform=macOS' -only-testing:ShortcutCycleTests/PressAndHoldTests/testFinalizeClosesCurrentSpaceSettingsWhenSelectedTargetLeavesCurrentSpace`
