### PR TITLE
[codex] Unify HUD quick tap and reveal flow

### DIFF
--- a/ShortcutCycle/ShortcutCycle/Models/AppGroup.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/AppGroup.swift
@@ -142,9 +142,9 @@ public enum AppCyclingLogic {
     /// - Parameters:
     ///   - items: List of available apps to cycle through
     ///   - currentFrontmostAppId: The bundle ID of the currently frontmost app
-    ///   - currentHUDSelectionId: The bundle ID currently selected in the HUD (if visible)
+    ///   - currentHUDSelectionId: The bundle ID currently selected in the HUD session (if any)
     ///   - lastActiveAppId: The bundle ID of the last active app in this group
-    ///   - isHUDVisible: Whether the HUD is currently visible
+    ///   - isHUDVisible: Whether a HUD session is already active (revealed or still preparing)
     ///   - prioritizeFrontmost: Whether a new cycle should advance from current frontmost app
     /// - Returns: The bundle ID of the next app to activate
     public static func nextAppId(
@@ -160,7 +160,7 @@ public enum AppCyclingLogic {
             return "" 
         }
         
-        // 1. If HUD is already visible, we are interacting with the list.
+        // 1. If a HUD session is already active, we are interacting with the list.
         // Cycle from the currently selected item in the HUD.
         if isHUDVisible, let currentID = currentHUDSelectionId {
             if let currentIndex = items.firstIndex(where: { $0.id == currentID }) {
@@ -172,7 +172,7 @@ public enum AppCyclingLogic {
             }
         }
         
-        // 2. HUD is NOT visible. This is a new cycle start.
+        // 2. No HUD session is active. This is a new cycle start.
         
         // Check if the frontmost app is part of our group
         if prioritizeFrontmost {

--- a/ShortcutCycle/ShortcutCycle/Services/AppSwitcher.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/AppSwitcher.swift
@@ -22,7 +22,11 @@ class AppSwitcher: @preconcurrency ObservableObject {
         app.unhide()
     }
     var activateRunningAppInstance: (NSRunningApplication) -> Bool = { app in
-        app.activate(options: .activateAllWindows)
+        if NSApp?.isActive == true {
+            NSApp?.yieldActivation(to: app)
+            return app.activate(from: .current, options: .activateAllWindows)
+        }
+        return app.activate(options: .activateAllWindows)
     }
     private var lastInvokedGroupId: UUID?
     private var cycleSessionState: CycleSessionState?
@@ -105,7 +109,7 @@ class AppSwitcher: @preconcurrency ObservableObject {
             items: resolvableItems
         )
 
-        let isHUDVisible = HUDManager.shared.isVisible
+        let isHUDVisible = HUDManager.shared.isSessionActive
         nextAppId = AppCyclingLogic.nextAppId(
             items: cycleItems,
             currentFrontmostAppId: frontmostAppUniqueId,
@@ -280,7 +284,7 @@ class AppSwitcher: @preconcurrency ObservableObject {
             items: resolvableItems
         )
 
-        let isHUDVisible = HUDManager.shared.isVisible
+        let isHUDVisible = HUDManager.shared.isSessionActive
         nextAppId = AppCyclingLogic.nextAppId(
             items: cycleItems,
             currentFrontmostAppId: frontmostAppUniqueId,

--- a/ShortcutCycle/ShortcutCycle/Services/AppSwitcher.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/AppSwitcher.swift
@@ -109,20 +109,20 @@ class AppSwitcher: @preconcurrency ObservableObject {
             items: resolvableItems
         )
 
-        let isHUDVisible = HUDManager.shared.isSessionActive
+        let isHUDSessionActive = HUDManager.shared.isSessionActive
         nextAppId = AppCyclingLogic.nextAppId(
             items: cycleItems,
             currentFrontmostAppId: frontmostAppUniqueId,
             currentHUDSelectionId: HUDManager.shared.currentSelectedAppId,
             lastActiveAppId: resolvedLastActiveId,
-            isHUDVisible: isHUDVisible,
+            isHUDVisible: isHUDSessionActive,
             prioritizeFrontmost: prioritizeFrontmost
         )
         nextAppId = resolveSessionNextAppId(
             groupId: group.id,
             itemIds: cycleItems.map(\.id),
             fallbackNextId: nextAppId,
-            isHUDVisible: isHUDVisible
+            isHUDVisible: isHUDSessionActive
         )
 
         // If no app from the group is running, launch the first app and show overlay
@@ -284,20 +284,20 @@ class AppSwitcher: @preconcurrency ObservableObject {
             items: resolvableItems
         )
 
-        let isHUDVisible = HUDManager.shared.isSessionActive
+        let isHUDSessionActive = HUDManager.shared.isSessionActive
         nextAppId = AppCyclingLogic.nextAppId(
             items: cycleItems,
             currentFrontmostAppId: frontmostAppUniqueId,
             currentHUDSelectionId: HUDManager.shared.currentSelectedAppId,
             lastActiveAppId: resolvedLastActiveId,
-            isHUDVisible: isHUDVisible,
+            isHUDVisible: isHUDSessionActive,
             prioritizeFrontmost: prioritizeFrontmost
         )
         nextAppId = resolveSessionNextAppId(
             groupId: group.id,
             itemIds: cycleItems.map(\.id),
             fallbackNextId: nextAppId,
-            isHUDVisible: isHUDVisible
+            isHUDVisible: isHUDSessionActive
         )
         
         // Find the HUDAppItem for the next app

--- a/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
@@ -689,33 +689,23 @@ class HUDManager: @preconcurrency ObservableObject {
     }
 
     private func checkModifiersHeld(currentFlags: NSEvent.ModifierFlags, required: NSEvent.ModifierFlags) -> Bool {
-        // Command (55, 54)
-        if required.contains(.command) {
-            if isKeyDown(55) || isKeyDown(54) { return true }
+        let isModifierHeld: (NSEvent.ModifierFlags, [Int]) -> Bool = { modifier, keyCodes in
+            guard required.contains(modifier) else {
+                return true
+            }
+
+            if keyCodes.contains(where: self.isKeyDown) {
+                return true
+            }
+
+            // Fallback to flags if the hardware check misses a transient state.
+            return currentFlags.contains(modifier)
         }
-        
-        // Option (58, 61)
-        if required.contains(.option) {
-            if isKeyDown(58) || isKeyDown(61) { return true }
-        }
-        
-        // Control (59, 62)
-        if required.contains(.control) {
-            if isKeyDown(59) || isKeyDown(62) { return true }
-        }
-        
-        // Shift (56, 60)
-        if required.contains(.shift) {
-            if isKeyDown(56) || isKeyDown(60) { return true }
-        }
-        
-        // Fallback to flags if hardware check fails (unlikely, but safe)
-        if required.contains(.command) && currentFlags.contains(.command) { return true }
-        if required.contains(.shift) && currentFlags.contains(.shift) { return true }
-        if required.contains(.option) && currentFlags.contains(.option) { return true }
-        if required.contains(.control) && currentFlags.contains(.control) { return true }
-        
-        return false
+
+        return isModifierHeld(.command, [55, 54])
+            && isModifierHeld(.option, [58, 61])
+            && isModifierHeld(.control, [59, 62])
+            && isModifierHeld(.shift, [56, 60])
     }
     
     private func handleFlagsChanged(event: NSEvent, required: NSEvent.ModifierFlags) {

--- a/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
@@ -190,13 +190,30 @@ class HUDManager: @preconcurrency ObservableObject {
         sessionPhase == .revealed
     }
 
+    private func resetSessionAfterAbortedReveal() {
+        sessionPhase = .idle
+        currentSelectedAppId = nil
+        currentShortcut = nil
+        pendingActiveAppId = nil
+        stopLooping()
+        clearEventMonitors()
+        clearKeyUpMonitors()
+
+        if let observer = appResignObserver {
+            NotificationCenter.default.removeObserver(observer)
+            appResignObserver = nil
+        }
+    }
+
     /// Schedule showing the HUD with macOS Command+Tab logic
     func scheduleShow(items: [HUDAppItem], activeAppId: String, modifierFlags: NSEvent.ModifierFlags?, shortcut: String?, activeKey: KeyboardShortcuts.Key? = nil, shouldActivate: Bool = true, immediate: Bool = false, onSelect: ((String) -> Void)? = nil, onFinalize: ((String) -> Void)? = nil) {
         // Cancel existing hide timer
         hideTimer?.invalidate()
         hideTimer = nil // Ensure we don't auto-hide while interacting
         
-        // Update callbacks
+        // Callbacks are session-scoped. If another shortcut invocation supersedes
+        // the current prepared/revealed session, the latest invocation owns the
+        // eventual select/finalize callbacks.
         self.onSelectCallback = onSelect
         self.onFinalizeCallback = onFinalize
         
@@ -348,7 +365,10 @@ class HUDManager: @preconcurrency ObservableObject {
         revealTimer?.invalidate()
         revealTimer = nil
 
-        guard let window else { return }
+        guard let window else {
+            resetSessionAfterAbortedReveal()
+            return
+        }
         guard sessionPhase != .revealed else {
             if activeKey != nil {
                 scheduleLoopStart()

--- a/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
@@ -138,7 +138,6 @@ class HUDManager: @preconcurrency ObservableObject {
     
     private var currentItems: [HUDAppItem] = []
 
-    private var previousFrontmostApp: NSRunningApplication?
     private var pendingActiveAppId: String?
     private var sessionPhase: HUDSessionPhase = .idle
     
@@ -209,12 +208,6 @@ class HUDManager: @preconcurrency ObservableObject {
         // Store items immediately so fast switch path can look up PID
         self.currentItems = items
         
-        // Capture the previous frontmost app only when starting a fresh session.
-        // We do this BEFORE we activate ourselves
-        if !isSessionActive {
-             self.previousFrontmostApp = NSWorkspace.shared.frontmostApplication
-        }
-
         if !isSessionActive {
             closeOffSpaceSettingsWindowIfNeeded()
             prepareAppForHUDPresentation()
@@ -748,6 +741,7 @@ class HUDManager: @preconcurrency ObservableObject {
         
         if window != nil || isSessionActive {
             hide() // Hide immediately
+            return
         }
         
         // Stop monitoring

--- a/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
@@ -48,7 +48,7 @@ class HUDWindow: NSPanel {
         self.backgroundColor = .clear
         self.isOpaque = false
         self.hasShadow = false
-        self.ignoresMouseEvents = false // Enable mouse events for selection
+        self.ignoresMouseEvents = true
     }
 }
 
@@ -56,6 +56,12 @@ class HUDWindow: NSPanel {
 
 @MainActor
 class HUDManager: @preconcurrency ObservableObject {
+    private enum HUDSessionPhase {
+        case idle
+        case preparedInvisible
+        case revealed
+    }
+
     static let shared = HUDManager()
     
     let objectWillChange = ObservableObjectPublisher()
@@ -78,11 +84,32 @@ class HUDManager: @preconcurrency ObservableObject {
     var currentModifierFlags: () -> NSEvent.ModifierFlags = {
         NSEvent.modifierFlags
     }
+    var isAppActive: () -> Bool = {
+        NSApp?.isActive == true
+    }
     var settingsWindowsProvider: () -> [NSWindow] = {
+        NSApp?.windows ?? []
+    }
+    var appWindowsProvider: () -> [NSWindow] = {
         NSApp?.windows ?? []
     }
     var closeWindow: (NSWindow) -> Void = { window in
         window.close()
+    }
+    var orderWindowBack: (NSWindow) -> Void = { window in
+        window.orderBack(nil)
+    }
+    var setWindowAlpha: (NSWindow, CGFloat) -> Void = { window, alpha in
+        window.alphaValue = alpha
+    }
+    var animateWindowAlpha: (NSWindow, CGFloat, TimeInterval) -> Void = { window, alpha, duration in
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = duration
+            window.animator().alphaValue = alpha
+        }
+    }
+    var setWindowIgnoresMouseEvents: (NSWindow, Bool) -> Void = { window, ignores in
+        window.ignoresMouseEvents = ignores
     }
     // `lazy` because the default captures `self` to call the private `activateOrLaunch` method.
     lazy var activatePendingTargetApp: (String) -> Void = { [weak self] bundleId in
@@ -99,9 +126,9 @@ class HUDManager: @preconcurrency ObservableObject {
     
     private var window: HUDWindow?
     private var hideTimer: Timer?
-    private var showTimer: Timer?
+    private var revealTimer: Timer?
     private var loopTimer: Timer?
-    private var keyUpMonitor: Any?
+    private var keyUpMonitors: [Any] = []
     private var eventMonitors: [Any] = []
     private var appResignObserver: NSObjectProtocol?
     
@@ -113,14 +140,18 @@ class HUDManager: @preconcurrency ObservableObject {
 
     private var previousFrontmostApp: NSRunningApplication?
     private var pendingActiveAppId: String?
-    private var didPresentHUDThisSession = false
+    private var sessionPhase: HUDSessionPhase = .idle
     
     // Track the currently selected app in the HUD
     public private(set) var currentSelectedAppId: String?
     private var currentShortcut: String?
     
     var isVisible: Bool {
-        window?.isVisible == true
+        sessionPhase == .revealed
+    }
+
+    var isSessionActive: Bool {
+        sessionPhase != .idle
     }
     
     /// True only when the repeating auto-cycle loop is active (not during the initial delay phase).
@@ -140,6 +171,25 @@ class HUDManager: @preconcurrency ObservableObject {
     
     private var onSelectCallback: ((String) -> Void)?
     private var onFinalizeCallback: ((String) -> Void)?
+    private let hudPresentationDelay: TimeInterval = 0.2
+
+    private func clearEventMonitors() {
+        for monitor in eventMonitors {
+            removeEventMonitor(monitor)
+        }
+        eventMonitors.removeAll()
+    }
+
+    private func clearKeyUpMonitors() {
+        for monitor in keyUpMonitors {
+            removeEventMonitor(monitor)
+        }
+        keyUpMonitors.removeAll()
+    }
+
+    private func isHUDRevealedThisSession() -> Bool {
+        sessionPhase == .revealed
+    }
 
     /// Schedule showing the HUD with macOS Command+Tab logic
     func scheduleShow(items: [HUDAppItem], activeAppId: String, modifierFlags: NSEvent.ModifierFlags?, shortcut: String?, activeKey: KeyboardShortcuts.Key? = nil, shouldActivate: Bool = true, immediate: Bool = false, onSelect: ((String) -> Void)? = nil, onFinalize: ((String) -> Void)? = nil) {
@@ -151,11 +201,7 @@ class HUDManager: @preconcurrency ObservableObject {
         self.onSelectCallback = onSelect
         self.onFinalizeCallback = onFinalize
         
-        let now = timeProvider.now
-        let isRepeated = lastRequestTime != nil && now.timeIntervalSince(lastRequestTime!) < 0.5
-
-        lastRequestTime = now
-        didPresentHUDThisSession = false
+        lastRequestTime = timeProvider.now
         
         // Store pending active app for fast switching
         self.pendingActiveAppId = shouldActivate ? activeAppId : nil
@@ -163,44 +209,37 @@ class HUDManager: @preconcurrency ObservableObject {
         // Store items immediately so fast switch path can look up PID
         self.currentItems = items
         
-        // Capture the previous frontmost app if we aren't already visible
+        // Capture the previous frontmost app only when starting a fresh session.
         // We do this BEFORE we activate ourselves
-        if window?.isVisible != true {
+        if !isSessionActive {
              self.previousFrontmostApp = NSWorkspace.shared.frontmostApplication
         }
-        
-        // If HUD is already visible, this is a repeated hit (cycling), or immediate is requested, show/update immediately
-        if (window?.isVisible == true) || isRepeated || immediate {
-            showTimer?.invalidate()
-            showTimer = nil
+
+        if !isSessionActive {
             closeOffSpaceSettingsWindowIfNeeded()
             prepareAppForHUDPresentation()
-            presentHUD(items: items, activeAppId: activeAppId, shortcut: shortcut)
-            startMonitoringModifiers(requiredModifiers: modifierFlags, activeKey: activeKey)
-            // Start loop AFTER monitoring is set up so isLoopKeyHeld is fresh
-            if activeKey != nil {
-                scheduleLoopStart()
+            prepareHUD(items: items, activeAppId: activeAppId, shortcut: shortcut, reveal: false)
+            sessionPhase = .preparedInvisible
+            startMonitoring(requiredModifiers: modifierFlags, activeKey: activeKey)
+
+            if immediate {
+                revealHUD(requiredModifiers: modifierFlags, activeKey: activeKey)
+            } else {
+                scheduleReveal(requiredModifiers: modifierFlags, activeKey: activeKey)
             }
             return
         }
 
-        // Otherwise, schedule show after a short delay (mimic "hold" to show)
-        showTimer?.invalidate()
-        showTimer = timerScheduler.schedule(timeInterval: 0.2, repeats: false) { [weak self] _ in // 200ms delay
-            Task { @MainActor in
-                self?.closeOffSpaceSettingsWindowIfNeeded()
-                self?.prepareAppForHUDPresentation()
-                self?.presentHUD(items: items, activeAppId: activeAppId, shortcut: shortcut)
-                self?.startMonitoringModifiers(requiredModifiers: modifierFlags, activeKey: activeKey)
-                // Start loop AFTER monitoring is set up so isLoopKeyHeld is fresh
-                if activeKey != nil {
-                    self?.scheduleLoopStart()
-                }
-            }
-        }
+        prepareHUD(items: items, activeAppId: activeAppId, shortcut: shortcut, reveal: isHUDRevealedThisSession())
 
-        // Monitor release globally while we wait to decide whether the HUD should appear.
-        startPreShowMonitoring(requiredModifiers: modifierFlags, activeKey: activeKey)
+        if isHUDRevealedThisSession() {
+            startMonitoring(requiredModifiers: modifierFlags, activeKey: activeKey)
+            if activeKey != nil {
+                scheduleLoopStart()
+            }
+        } else {
+            revealHUD(requiredModifiers: modifierFlags, activeKey: activeKey)
+        }
     }
 
     private func closeOffSpaceSettingsWindowIfNeeded() {
@@ -229,6 +268,15 @@ class HUDManager: @preconcurrency ObservableObject {
         closeWindow(settingsWindow)
     }
 
+    private func orderCurrentSpaceWindowsBackIfNeeded() {
+        for visibleWindow in appWindowsProvider() where visibleWindow !== window {
+            guard visibleWindow.isVisible, visibleWindow.isOnActiveSpace else {
+                continue
+            }
+            orderWindowBack(visibleWindow)
+        }
+    }
+
     private func prepareAppForHUDPresentation() {
         guard let app = NSApp else { return }
 
@@ -245,7 +293,7 @@ class HUDManager: @preconcurrency ObservableObject {
         }
     }
     
-    private func presentHUD(items: [HUDAppItem], activeAppId: String, shortcut: String?) {
+    private func prepareHUD(items: [HUDAppItem], activeAppId: String, shortcut: String?, reveal: Bool) {
         // Prepare Window if needed
         if window == nil {
             window = HUDWindow()
@@ -253,7 +301,6 @@ class HUDManager: @preconcurrency ObservableObject {
 
         self.currentItems = items
         currentSelectedAppId = activeAppId
-        didPresentHUDThisSession = true
 
         if let shortcut = shortcut {
             self.currentShortcut = shortcut
@@ -285,9 +332,46 @@ class HUDManager: @preconcurrency ObservableObject {
             window.setFrame(NSRect(x: x, y: y, width: viewSize.width, height: viewSize.height), display: true)
         }
 
+        if reveal {
+            setWindowIgnoresMouseEvents(window, false)
+            setWindowAlpha(window, 1.0)
+        } else {
+            setWindowIgnoresMouseEvents(window, true)
+            setWindowAlpha(window, 0.0)
+        }
         window.orderFront(nil)
-        // Note: Loop scheduling is handled by scheduleShow() AFTER startMonitoringModifiers(),
-        // not here, to ensure isLoopKeyHeld is freshly set before the loop decision.
+    }
+
+    private func scheduleReveal(requiredModifiers: NSEvent.ModifierFlags?, activeKey: KeyboardShortcuts.Key?) {
+        revealTimer?.invalidate()
+        revealTimer = timerScheduler.schedule(timeInterval: hudPresentationDelay, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                self?.revealHUD(requiredModifiers: requiredModifiers, activeKey: activeKey)
+            }
+        }
+    }
+
+    private func revealHUD(requiredModifiers: NSEvent.ModifierFlags?, activeKey: KeyboardShortcuts.Key?, shouldStartLoop: Bool? = nil) {
+        revealTimer?.invalidate()
+        revealTimer = nil
+
+        guard let window else { return }
+        guard sessionPhase != .revealed else {
+            if activeKey != nil {
+                scheduleLoopStart()
+            }
+            return
+        }
+
+        sessionPhase = .revealed
+        setWindowIgnoresMouseEvents(window, false)
+        animateWindowAlpha(window, 1.0, 0.12)
+        startMonitoring(requiredModifiers: requiredModifiers, activeKey: activeKey)
+
+        let startLoop = shouldStartLoop ?? (activeKey != nil && isLoopKeyHeld)
+        if startLoop {
+            scheduleLoopStart()
+        }
     }
     
     private func scheduleLoopStart() {
@@ -309,71 +393,19 @@ class HUDManager: @preconcurrency ObservableObject {
 
     internal var isLoopKeyHeld: Bool = false
 
-    private func startPreShowMonitoring(requiredModifiers: NSEvent.ModifierFlags?, activeKey: KeyboardShortcuts.Key? = nil) {
-        for monitor in eventMonitors {
-            removeEventMonitor(monitor)
-        }
-        eventMonitors.removeAll()
-
-        if let keyMonitor = keyUpMonitor {
-            removeEventMonitor(keyMonitor)
-            keyUpMonitor = nil
-        }
-
-        guard let required = requiredModifiers, !required.isEmpty else {
-            return
-        }
-
-        let flagsMonitor = addGlobalEventMonitor(.flagsChanged) { [weak self] event in
-            Task { @MainActor in
-                self?.handleFlagsChanged(event: event, required: required)
-            }
-        }
-        if let flagsMonitor = flagsMonitor {
-            eventMonitors.append(flagsMonitor)
-        }
-
-        if let activeKey = activeKey {
-            keyUpMonitor = addGlobalEventMonitor(.keyUp) { [weak self] event in
-                guard Int(event.keyCode) == activeKey.rawValue else { return }
-
-                Task { @MainActor in
-                    guard let self else { return }
-                    self.isLoopKeyHeld = false
-
-                    if let timer = self.showTimer, timer.isValid {
-                        let flags = self.currentModifierFlags()
-                        if self.checkModifiersHeld(currentFlags: flags, required: required) {
-                            self.showTimer?.fire()
-                        } else {
-                            self.showTimer?.invalidate()
-                            self.showTimer = nil
-                        }
-                    }
-
-                    self.stopLooping()
-                }
-            }
-        }
-    }
-    
-    private func startMonitoringModifiers(requiredModifiers: NSEvent.ModifierFlags?, activeKey: KeyboardShortcuts.Key? = nil) {
-        
+    private func startMonitoring(requiredModifiers: NSEvent.ModifierFlags?, activeKey: KeyboardShortcuts.Key? = nil) {
         // Check if we are already looping for this key. If so, DO NOT reset monitors.
-        if let active = activeKey, let current = currentLoopKey, active.rawValue == current, loopTimer != nil {
+        if sessionPhase == .revealed,
+           let active = activeKey,
+           let current = currentLoopKey,
+           active.rawValue == current,
+           loopTimer != nil {
             return
         }
         
         // Stop existing monitors
-        for monitor in eventMonitors {
-            removeEventMonitor(monitor)
-        }
-        eventMonitors.removeAll()
-        
-        if let keyMonitor = keyUpMonitor {
-            removeEventMonitor(keyMonitor)
-            keyUpMonitor = nil
-        }
+        clearEventMonitors()
+        clearKeyUpMonitors()
         loopTimer?.invalidate()
         loopTimer = nil
         isRepeatingLoopActive = false
@@ -392,85 +424,120 @@ class HUDManager: @preconcurrency ObservableObject {
              return
         }
         
-        // Check if ANY of the required modifiers are currently held.
-        let currentFlags = currentModifierFlags()
-        if !checkModifiersHeld(currentFlags: currentFlags, required: required) {
-             // Give a tiny grace period for state to settle or for fast release.
-             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
-                 guard let self = self else { return }
-                 let flags = self.currentModifierFlags()
-                 if !self.checkModifiersHeld(currentFlags: flags, required: required) {
-                     self.finalizeSwitchAndHide()
-                 }
-             }
-        }
-        
-        // Monitor flags changed - use LOCAL monitor now since we are active
-        let flagsMonitor = addLocalEventMonitor(.flagsChanged) { [weak self] event in
-            Task { @MainActor in
-                self?.handleFlagsChanged(event: event, required: required)
+        let addFlagsMonitor: (Bool) -> Void = { [weak self] isGlobal in
+            guard let self else { return }
+            if isGlobal {
+                let flagsMonitor = self.addGlobalEventMonitor(.flagsChanged) { [weak self] event in
+                    Task { @MainActor in
+                        self?.handleFlagsChanged(event: event, required: required)
+                    }
+                }
+                if let flagsMonitor {
+                    self.eventMonitors.append(flagsMonitor)
+                }
+                return
             }
-            return event
+
+            let flagsMonitor = self.addLocalEventMonitor(.flagsChanged) { [weak self] event in
+                Task { @MainActor in
+                    self?.handleFlagsChanged(event: event, required: required)
+                }
+                return event
+            }
+            if let flagsMonitor {
+                self.eventMonitors.append(flagsMonitor)
+            }
         }
-        if let flagsMonitor = flagsMonitor {
-            eventMonitors.append(flagsMonitor)
+
+        addFlagsMonitor(false)
+        if sessionPhase != .revealed {
+            // During the invisible preparation phase we watch both scopes. Once the
+            // HUD is revealed we re-install local-only monitoring.
+            addFlagsMonitor(true)
+        }
+
+        if sessionPhase == .revealed {
+            // Give a tiny grace period for state to settle or for fast release.
+            let currentFlags = currentModifierFlags()
+            if !checkModifiersHeld(currentFlags: currentFlags, required: required) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+                    guard let self else { return }
+                    let flags = self.currentModifierFlags()
+                    if self.sessionPhase == .revealed,
+                       !self.checkModifiersHeld(currentFlags: flags, required: required) {
+                        self.finalizeSwitchAndHide()
+                    }
+                }
+            }
         }
         
         // 2. Loop Logic (Hyper Key / Hold Key)
         if let activeKey = activeKey {
             currentLoopKey = activeKey.rawValue
             isLoopKeyHeld = true
-            
-            // Start listening for Key Up of this specific key
-            keyUpMonitor = addLocalEventMonitor(.keyUp) { [weak self] event in
-                let keyCode = Int(event.keyCode)
-                if keyCode == activeKey.rawValue {
-                    Task { @MainActor in
-                        guard let self = self else { return }
-                        self.isLoopKeyHeld = false
-                        
-                        // Check if HUD is waiting to show?
-                        if let timer = self.showTimer, timer.isValid {
-                            // "Quick Tap" OR "Peek"? Check Modifiers!
-                            let currentFlags = self.currentModifierFlags()
-                            if self.checkModifiersHeld(currentFlags: currentFlags, required: required) {
-                                // Modifiers HELD -> PEEK Mode!
-                                // Show HUD immediately, but DO NOT start looping (since key is up).
-                                self.showTimer?.fire() // Trigger manual fire to show HUD
-                            } else {
-                                // Modifiers RELEASED -> Quick Tap!
-                                // Cancel HUD.
-                                self.showTimer?.invalidate()
-                                self.showTimer = nil
-                            }
+
+            let handleKeyUp: (NSEvent) -> Void = { [weak self] event in
+                guard Int(event.keyCode) == activeKey.rawValue else { return }
+
+                Task { @MainActor in
+                    guard let self else { return }
+                    self.isLoopKeyHeld = false
+
+                    if let timer = self.revealTimer, timer.isValid {
+                        let currentFlags = self.currentModifierFlags()
+                        if self.checkModifiersHeld(currentFlags: currentFlags, required: required) {
+                            // "Peek" behavior: reveal the HUD immediately, but do not
+                            // start auto-cycling because the loop key was released.
+                            self.revealHUD(requiredModifiers: requiredModifiers, activeKey: activeKey, shouldStartLoop: false)
+                        } else {
+                            self.revealTimer?.invalidate()
+                            self.revealTimer = nil
                         }
-                        
-                        self.stopLooping()
                     }
+
+                    self.stopLooping()
                 }
-                return event
             }
-            // Note: Loop timer is NOT started here anymore. It's started by presentHUD -> scheduleLoopStart.
-            
+
+            if sessionPhase != .revealed,
+               let keyMonitor = addGlobalEventMonitor(.keyUp, handleKeyUp) {
+                keyUpMonitors.append(keyMonitor)
+            }
+
+            if let keyMonitor = addLocalEventMonitor(.keyUp, { event in
+                handleKeyUp(event)
+                return event
+            }) {
+                keyUpMonitors.append(keyMonitor)
+            }
         }
-        
+
+        guard sessionPhase == .revealed else {
+            return
+        }
+
         // Monitor Arrow Keys AND Loop Key for "Heartbeat"
         let keyMonitor = addLocalEventMonitor(.keyDown) { [weak self] event in
-            
-            // Heartbeat: If this is the active loop key, update the timestamp
+            Task { @MainActor in
+                // Heartbeat: If this is the active loop key, update the timestamp
+                if let active = activeKey, Int(event.keyCode) == active.rawValue {
+                    self?.lastLocalKeyDownTime = self?.timeProvider.now
+                    return
+                }
+
+                // Stop looping if user calculates manually navigation (Arrows, etc)
+                // But NOT if it's just the loop key repeating!
+                if let active = activeKey, Int(event.keyCode) != active.rawValue {
+                    self?.stopLooping()
+                } else if activeKey == nil {
+                    self?.stopLooping()
+                }
+            }
+
             if let active = activeKey, Int(event.keyCode) == active.rawValue {
-                self?.lastLocalKeyDownTime = self?.timeProvider.now
                 return nil // Consume the event so it doesn't beep or do other things
             }
-            
-            // Stop looping if user calculates manually navigation (Arrows, etc)
-            // But NOT if it's just the loop key repeating!
-            if let active = activeKey, Int(event.keyCode) != active.rawValue {
-                self?.stopLooping()
-            } else if activeKey == nil {
-                self?.stopLooping()
-            }
-            
+
             return self?.handleKeyDown(event: event) ?? event
         }
         if let keyMonitor = keyMonitor {
@@ -513,10 +580,7 @@ class HUDManager: @preconcurrency ObservableObject {
         loopTimer = nil
         isRepeatingLoopActive = false
         currentLoopKey = nil // Reset so we accept new requests
-        if let monitor = keyUpMonitor {
-            removeEventMonitor(monitor)
-            keyUpMonitor = nil
-        }
+        clearKeyUpMonitors()
     }
     
     private func selectNextApp() {
@@ -555,7 +619,7 @@ class HUDManager: @preconcurrency ObservableObject {
         let nextIndex = (currentIndex + 1) % count
         let newId = currentItems[nextIndex].id
         
-        presentHUD(items: currentItems, activeAppId: newId, shortcut: nil)
+        prepareHUD(items: currentItems, activeAppId: newId, shortcut: nil, reveal: true)
         
         // Update pending ID and notify listener
         self.pendingActiveAppId = newId
@@ -598,7 +662,7 @@ class HUDManager: @preconcurrency ObservableObject {
         
         if nextIndex != currentIndex {
             let newId = currentItems[nextIndex].id
-            presentHUD(items: currentItems, activeAppId: newId, shortcut: nil)
+            prepareHUD(items: currentItems, activeAppId: newId, shortcut: nil, reveal: true)
             self.pendingActiveAppId = newId
             self.onSelectCallback?(newId)
             return nil // Consume event
@@ -659,8 +723,8 @@ class HUDManager: @preconcurrency ObservableObject {
 
     private func finalizeSwitchAndHide() {
         // Modifiers released
-        showTimer?.invalidate() // Cancel pending show
-        showTimer = nil
+        revealTimer?.invalidate()
+        revealTimer = nil
 
         // KEY CHANGE: Session has ended.
         // Clear the lastRequestTime and lastLocalKeyDownTime tracking so the next interaction is fresh.
@@ -673,22 +737,22 @@ class HUDManager: @preconcurrency ObservableObject {
 
         // Fast switch: user released keys before HUD appeared or while it was visible
         if let pendingId = pendingActiveAppId {
-            if didPresentHUDThisSession {
+            if isHUDRevealedThisSession() {
                 closeVisibleSettingsWindowIfNeeded(beforeActivating: pendingId)
+            } else {
+                orderCurrentSpaceWindowsBackIfNeeded()
             }
             activatePendingTargetApp(pendingId)
             pendingActiveAppId = nil
         }
         
-        if window?.isVisible == true {
+        if window != nil || isSessionActive {
             hide() // Hide immediately
         }
         
         // Stop monitoring
-        for monitor in eventMonitors {
-            removeEventMonitor(monitor)
-        }
-        eventMonitors.removeAll()
+        clearEventMonitors()
+        clearKeyUpMonitors()
         
         if let observer = appResignObserver {
             NotificationCenter.default.removeObserver(observer)
@@ -703,6 +767,16 @@ class HUDManager: @preconcurrency ObservableObject {
         return list.contains { ($0[kCGWindowOwnerPID as String] as? Int32) == pid }
     }
 
+    private func activateRunningTargetApp(_ app: NSRunningApplication) {
+        if isAppActive() {
+            NSApp?.yieldActivation(to: app)
+            _ = app.activate(from: .current, options: .activateAllWindows)
+            return
+        }
+
+        _ = app.activate(options: .activateAllWindows)
+    }
+
     private func activateOrLaunch(bundleId: String) {
         // Resolve the real bundle ID from currentItems (bundleId may be a composite "bundleId::pid")
         let item = currentItems.first(where: { $0.id == bundleId || $0.bundleId == bundleId })
@@ -712,7 +786,10 @@ class HUDManager: @preconcurrency ObservableObject {
            let app = NSRunningApplication.runningApplications(withBundleIdentifier: realBundleId)
                .first(where: { $0.processIdentifier == pid }) {
             app.unhide()
-            app.activate(options: .activateAllWindows)
+            // Quick-tap blind switching can happen while ShortcutCycle is still the
+            // active app (for example with Settings or menu UI involved). Yield our
+            // activation first so the target app can take frontmost focus reliably.
+            activateRunningTargetApp(app)
             // If all windows are minimized, activate() succeeds but nothing appears on screen.
             // After a short delay, check via CGWindowList (no Accessibility permission needed);
             // if no visible windows exist, re-activate the specific instance to ensure it is
@@ -721,7 +798,7 @@ class HUDManager: @preconcurrency ObservableObject {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
                 guard let self else { return }
                 guard !self.hasVisibleWindows(pid: pid) else { return }
-                app.activate(options: .activateAllWindows)
+                self.activateRunningTargetApp(app)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
                     self?.launchApp(bundleIdentifier: realBundleId)
                 }
@@ -759,17 +836,19 @@ class HUDManager: @preconcurrency ObservableObject {
     /// Hide the HUD
     func hide() {
         fireOnFinalizeIfNeeded()
-        let hadPresentedHUD = didPresentHUDThisSession
+        let hadRevealedHUD = isHUDRevealedThisSession()
         window?.orderOut(nil)
         window = nil
         currentSelectedAppId = nil
         currentShortcut = nil
-        didPresentHUDThisSession = false
+        sessionPhase = .idle
 
         // Ensure we activate the pending app if it exists (fallback)
         if let pendingId = pendingActiveAppId {
-            if hadPresentedHUD {
+            if hadRevealedHUD {
                 closeVisibleSettingsWindowIfNeeded(beforeActivating: pendingId)
+            } else {
+                orderCurrentSpaceWindowsBackIfNeeded()
             }
             activatePendingTargetApp(pendingId)
             pendingActiveAppId = nil
@@ -780,15 +859,14 @@ class HUDManager: @preconcurrency ObservableObject {
 
         hideTimer?.invalidate()
         hideTimer = nil
-        showTimer?.invalidate()
-        showTimer = nil
+        revealTimer?.invalidate()
+        revealTimer = nil
         lastLocalKeyDownTime = nil
+        lastRequestTime = nil
         stopLooping()
         
-        for monitor in eventMonitors {
-            removeEventMonitor(monitor)
-        }
-        eventMonitors.removeAll()
+        clearEventMonitors()
+        clearKeyUpMonitors()
         
         if let observer = appResignObserver {
             NotificationCenter.default.removeObserver(observer)

--- a/ShortcutCycle/ShortcutCycleTests/AppSwitcherTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/AppSwitcherTests.swift
@@ -30,7 +30,11 @@ final class AppSwitcherTests: XCTestCase {
             app.unhide()
         }
         switcher.activateRunningAppInstance = { app in
-            app.activate(options: .activateAllWindows)
+            if NSApp?.isActive == true {
+                NSApp?.yieldActivation(to: app)
+                return app.activate(from: .current, options: .activateAllWindows)
+            }
+            return app.activate(options: .activateAllWindows)
         }
         NSApp?.unhide(nil)
     }

--- a/ShortcutCycle/ShortcutCycleTests/PressAndHoldTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/PressAndHoldTests.swift
@@ -32,18 +32,21 @@ final class PressAndHoldTests: XCTestCase {
 
         func fireLastTimer() {
             guard let last = scheduledTimers.last else { return }
+            guard last.2.isValid else { return }
             last.3(last.2)
         }
 
         /// Fire the most recent non-repeating timer (delay timer)
         func fireLastNonRepeatingTimer() {
             guard let entry = scheduledTimers.last(where: { !$0.1 }) else { return }
+            guard entry.2.isValid else { return }
             entry.3(entry.2)
         }
 
         /// Fire the most recent repeating timer (loop timer)
         func fireLastRepeatingTimer() {
             guard let entry = scheduledTimers.last(where: { $0.1 }) else { return }
+            guard entry.2.isValid else { return }
             entry.3(entry.2)
         }
     }
@@ -447,6 +450,88 @@ final class PressAndHoldTests: XCTestCase {
     }
 
     @MainActor
+    func testPeekThenModifierReleaseFinalizesAndActivatesPendingTarget() async throws {
+        let settingsWindow = MockWindow(
+            identifier: NSUserInterfaceItemIdentifier("settings"),
+            isVisible: true,
+            isOnActiveSpace: true
+        )
+        var events: [String] = []
+
+        manager.currentModifierFlags = { [.option] }
+        manager.settingsWindowsProvider = { [settingsWindow] }
+        manager.appWindowsProvider = { [settingsWindow] }
+        manager.closeWindow = { _ in
+            events.append("close")
+        }
+        manager.orderWindowBack = { _ in
+            events.append("back")
+        }
+        manager.targetLeavesCurrentSpace = { _ in true }
+        manager.activatePendingTargetApp = { _ in
+            events.append("activate")
+        }
+
+        manager.scheduleShow(
+            items: [
+                HUDAppItem(bundleId: "com.test.1", name: "Test 1", icon: nil),
+                HUDAppItem(bundleId: "com.test.2", name: "Test 2", icon: nil)
+            ],
+            activeAppId: "com.test.1",
+            modifierFlags: [.option],
+            shortcut: "Opt+1",
+            activeKey: .a
+        )
+
+        let keyUpHandler = try XCTUnwrap(latestLocalMonitorHandler(for: .keyUp))
+        _ = keyUpHandler(try makeKeyEvent(type: .keyUp, keyCode: KeyboardShortcuts.Key.a.rawValue, modifierFlags: [.option]))
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertTrue(manager.isVisible, "Peek should reveal the HUD before modifier release")
+
+        let flagsHandler = try XCTUnwrap(latestLocalMonitorHandler(for: .flagsChanged))
+        _ = flagsHandler(try makeFlagsChangedEvent(modifierFlags: []))
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertFalse(manager.isSessionActive, "Modifier release after a peek should end the HUD session")
+        XCTAssertFalse(manager.isVisible, "Modifier release after a peek should hide the HUD")
+        XCTAssertEqual(events, ["close", "activate"], "Peek finalize should use the revealed cleanup path and not order current-space windows back")
+    }
+
+    @MainActor
+    func testFullReleaseDuringPreparedInvisibleCancelsRevealWithoutShowingHUD() async throws {
+        manager.currentModifierFlags = { [] }
+
+        manager.scheduleShow(
+            items: [
+                HUDAppItem(bundleId: "com.test.1", name: "Test 1", icon: nil),
+                HUDAppItem(bundleId: "com.test.2", name: "Test 2", icon: nil)
+            ],
+            activeAppId: "com.test.1",
+            modifierFlags: [.option],
+            shortcut: "Opt+1",
+            activeKey: .a
+        )
+
+        XCTAssertFalse(manager.isVisible, "HUD should start invisible during the prepared phase")
+
+        let keyUpHandler = try XCTUnwrap(latestLocalMonitorHandler(for: .keyUp))
+        _ = keyUpHandler(try makeKeyEvent(type: .keyUp, keyCode: KeyboardShortcuts.Key.a.rawValue, modifierFlags: []))
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertFalse(manager.isVisible, "Releasing the loop key together with modifiers should not reveal the HUD")
+
+        timerMock.fireLastNonRepeatingTimer()
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertFalse(manager.isVisible, "Cancelling the reveal timer should prevent any later phantom reveal")
+    }
+
+    @MainActor
     func testFinalizeClosesCurrentSpaceSettingsWhenSelectedTargetLeavesCurrentSpace() async throws {
         let settingsWindow = MockWindow(
             identifier: NSUserInterfaceItemIdentifier("settings"),
@@ -523,8 +608,6 @@ final class PressAndHoldTests: XCTestCase {
     @MainActor
     func testFinalizeRequiresAllConfiguredModifiersToRemainHeld() async throws {
         var activateCount = 0
-
-        manager.currentModifierFlags = { [.command] }
         manager.activatePendingTargetApp = { _ in
             activateCount += 1
         }
@@ -675,6 +758,32 @@ final class PressAndHoldTests: XCTestCase {
         await Task.yield()
 
         XCTAssertEqual(finalizedAppIds, ["com.test.finalize::41"], "Finalize callback should fire exactly once with the pending selection")
+    }
+
+    @MainActor
+    func testFinalizeFallsBackToCurrentSelectionWhenNoPendingTargetExists() async throws {
+        var finalizedAppIds: [String] = []
+
+        manager.currentModifierFlags = { [.option] }
+
+        manager.scheduleShow(
+            items: [HUDAppItem(bundleId: "com.test.fallback", pid: 71, name: "Fallback Target")],
+            activeAppId: "com.test.fallback::71",
+            modifierFlags: [.option],
+            shortcut: "Opt+1",
+            shouldActivate: false,
+            immediate: true,
+            onFinalize: { appId in
+                finalizedAppIds.append(appId)
+            }
+        )
+
+        let flagsHandler = try XCTUnwrap(latestLocalMonitorHandler(for: .flagsChanged))
+        _ = flagsHandler(try makeFlagsChangedEvent(modifierFlags: []))
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(finalizedAppIds, ["com.test.fallback::71"], "Finalize should fall back to the current HUD selection when there is no pending activation target")
     }
 
     @MainActor

--- a/ShortcutCycle/ShortcutCycleTests/PressAndHoldTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/PressAndHoldTests.swift
@@ -19,32 +19,32 @@ final class PressAndHoldTests: XCTestCase {
     }
 
     class MockTimerScheduler: TimerScheduler {
-        // (interval, repeats, block)
-        var scheduledTimers: [(TimeInterval, Bool, (Timer) -> Void)] = []
+        // (interval, repeats, timer, block)
+        var scheduledTimers: [(TimeInterval, Bool, Timer, (Timer) -> Void)] = []
         var lastTimer: Timer?
 
         func schedule(timeInterval: TimeInterval, repeats: Bool, block: @escaping (Timer) -> Void) -> Timer {
-            let timer = Timer() // Dummy
-            scheduledTimers.append((timeInterval, repeats, block))
+            let timer = Timer(timeInterval: timeInterval, repeats: repeats) { _ in }
+            scheduledTimers.append((timeInterval, repeats, timer, block))
             lastTimer = timer
             return timer
         }
 
         func fireLastTimer() {
             guard let last = scheduledTimers.last else { return }
-            last.2(Timer())
+            last.3(last.2)
         }
 
         /// Fire the most recent non-repeating timer (delay timer)
         func fireLastNonRepeatingTimer() {
             guard let entry = scheduledTimers.last(where: { !$0.1 }) else { return }
-            entry.2(Timer())
+            entry.3(entry.2)
         }
 
         /// Fire the most recent repeating timer (loop timer)
         func fireLastRepeatingTimer() {
             guard let entry = scheduledTimers.last(where: { $0.1 }) else { return }
-            entry.2(Timer())
+            entry.3(entry.2)
         }
     }
 
@@ -192,6 +192,27 @@ final class PressAndHoldTests: XCTestCase {
                 charactersIgnoringModifiers: "",
                 isARepeat: false,
                 keyCode: 58
+            )
+        )
+    }
+
+    private func makeKeyEvent(
+        type: NSEvent.EventType,
+        keyCode: Int,
+        modifierFlags: NSEvent.ModifierFlags = []
+    ) throws -> NSEvent {
+        try XCTUnwrap(
+            NSEvent.keyEvent(
+                with: type,
+                location: .zero,
+                modifierFlags: modifierFlags,
+                timestamp: 0,
+                windowNumber: 0,
+                context: nil,
+                characters: "a",
+                charactersIgnoringModifiers: "a",
+                isARepeat: false,
+                keyCode: UInt16(keyCode)
             )
         )
     }
@@ -397,6 +418,35 @@ final class PressAndHoldTests: XCTestCase {
     }
 
     @MainActor
+    func testPeekRevealsHUDWithoutStartingLoopWhenLoopKeyIsReleasedDuringPreparedInvisible() async throws {
+        manager.currentModifierFlags = { [.option] }
+
+        manager.scheduleShow(
+            items: [
+                HUDAppItem(bundleId: "com.test.1", name: "Test 1", icon: nil),
+                HUDAppItem(bundleId: "com.test.2", name: "Test 2", icon: nil)
+            ],
+            activeAppId: "com.test.1",
+            modifierFlags: [.option],
+            shortcut: "Opt+1",
+            activeKey: .a
+        )
+
+        XCTAssertFalse(manager.isVisible, "HUD should still be invisible during the prepared phase")
+
+        let keyUpHandler = try XCTUnwrap(latestLocalMonitorHandler(for: .keyUp))
+        _ = keyUpHandler(try makeKeyEvent(type: .keyUp, keyCode: KeyboardShortcuts.Key.a.rawValue, modifierFlags: [.option]))
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertTrue(manager.isVisible, "Releasing only the loop key should reveal the HUD for peeking")
+        XCTAssertFalse(manager.isLooping, "Peek should not start the repeating loop")
+        XCTAssertFalse(manager.isRepeatingLoopActive, "Peek should leave the repeating loop inactive")
+        XCTAssertEqual(windowAlphaChanges.last, 1, "Peek reveal should animate the HUD to full opacity")
+        XCTAssertEqual(mouseInteractionStates.last, false, "Peek reveal should allow HUD interaction")
+    }
+
+    @MainActor
     func testFinalizeClosesCurrentSpaceSettingsWhenSelectedTargetLeavesCurrentSpace() async throws {
         let settingsWindow = MockWindow(
             identifier: NSUserInterfaceItemIdentifier("settings"),
@@ -571,6 +621,56 @@ final class PressAndHoldTests: XCTestCase {
         await Task.yield()
 
         XCTAssertEqual(Array(events.prefix(2)), ["back", "activate"])
+    }
+
+    @MainActor
+    func testFinalizeFiresOnFinalizeExactlyOnce() async throws {
+        var finalizedAppIds: [String] = []
+
+        manager.currentModifierFlags = { [.option] }
+
+        manager.scheduleShow(
+            items: [HUDAppItem(bundleId: "com.test.finalize", pid: 41, name: "Finalize Target")],
+            activeAppId: "com.test.finalize::41",
+            modifierFlags: [.option],
+            shortcut: "Opt+1",
+            immediate: true,
+            onFinalize: { appId in
+                finalizedAppIds.append(appId)
+            }
+        )
+
+        let flagsHandler = try XCTUnwrap(latestLocalMonitorHandler(for: .flagsChanged))
+        _ = flagsHandler(try makeFlagsChangedEvent(modifierFlags: []))
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(finalizedAppIds, ["com.test.finalize::41"], "Finalize callback should fire exactly once with the pending selection")
+    }
+
+    @MainActor
+    func testPreparedInvisibleFinalizeWithShouldActivateFalseDoesNotActivatePendingTarget() async throws {
+        var activateCount = 0
+
+        manager.activatePendingTargetApp = { _ in
+            activateCount += 1
+        }
+
+        manager.scheduleShow(
+            items: [HUDAppItem(bundleId: "com.test.passive", pid: 52, name: "Passive Target")],
+            activeAppId: "com.test.passive::52",
+            modifierFlags: [.option],
+            shortcut: "Opt+1",
+            shouldActivate: false
+        )
+
+        let flagsHandler = try XCTUnwrap(latestLocalMonitorHandler(for: .flagsChanged))
+        _ = flagsHandler(try makeFlagsChangedEvent(modifierFlags: []))
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(activateCount, 0, "Prepared invisible sessions that opted out of activation should not activate a pending target on finalize")
+        XCTAssertFalse(manager.isSessionActive, "Finalize should still fully tear down the prepared session")
     }
 
     @MainActor

--- a/ShortcutCycle/ShortcutCycleTests/PressAndHoldTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/PressAndHoldTests.swift
@@ -57,6 +57,8 @@ final class PressAndHoldTests: XCTestCase {
     var localMonitorHandlers: [(NSEvent.EventTypeMask, (NSEvent) -> NSEvent?)]!
     var globalMonitorHandlers: [(NSEvent.EventTypeMask, (NSEvent) -> Void)]!
     var removedMonitorCount: Int!
+    var windowAlphaChanges: [CGFloat]!
+    var mouseInteractionStates: [Bool]!
 
     // Saved originals for restoration in tearDown
     private var savedActivatePendingTargetApp: ((String) -> Void)!
@@ -73,6 +75,8 @@ final class PressAndHoldTests: XCTestCase {
         localMonitorHandlers = []
         globalMonitorHandlers = []
         removedMonitorCount = 0
+        windowAlphaChanges = []
+        mouseInteractionStates = []
 
         // Save originals before overriding (these use private methods, so restore by value)
         savedActivatePendingTargetApp = manager.activatePendingTargetApp
@@ -98,9 +102,23 @@ final class PressAndHoldTests: XCTestCase {
             self?.removedMonitorCount += 1
         }
         manager.currentModifierFlags = { [] }
+        manager.isAppActive = { true }
         manager.settingsWindowsProvider = { [] }
+        manager.appWindowsProvider = { [] }
         manager.closeWindow = { window in
             window.close()
+        }
+        manager.orderWindowBack = { window in
+            window.orderBack(nil)
+        }
+        manager.setWindowAlpha = { [weak self] _, alpha in
+            self?.windowAlphaChanges.append(alpha)
+        }
+        manager.animateWindowAlpha = { [weak self] _, alpha, _ in
+            self?.windowAlphaChanges.append(alpha)
+        }
+        manager.setWindowIgnoresMouseEvents = { [weak self] _, ignores in
+            self?.mouseInteractionStates.append(ignores)
         }
         manager.targetLeavesCurrentSpace = { _ in false }
 
@@ -130,8 +148,19 @@ final class PressAndHoldTests: XCTestCase {
         }
         manager.removeEventMonitor = { NSEvent.removeMonitor($0) }
         manager.currentModifierFlags = { NSEvent.modifierFlags }
+        manager.isAppActive = { NSApp?.isActive == true }
         manager.settingsWindowsProvider = { NSApp?.windows ?? [] }
+        manager.appWindowsProvider = { NSApp?.windows ?? [] }
         manager.closeWindow = { $0.close() }
+        manager.orderWindowBack = { $0.orderBack(nil) }
+        manager.setWindowAlpha = { $0.alphaValue = $1 }
+        manager.animateWindowAlpha = { window, alpha, duration in
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = duration
+                window.animator().alphaValue = alpha
+            }
+        }
+        manager.setWindowIgnoresMouseEvents = { $0.ignoresMouseEvents = $1 }
         manager.activatePendingTargetApp = savedActivatePendingTargetApp
         manager.targetLeavesCurrentSpace = savedTargetLeavesCurrentSpace
     }
@@ -179,9 +208,14 @@ final class PressAndHoldTests: XCTestCase {
             shortcut: "Opt+1"
         )
 
-        // Expect timer scheduled (waiting for hold)
-        XCTAssertEqual(timerMock.scheduledTimers.count, 1, "Should schedule a timer for hold detection")
-        XCTAssertFalse(manager.isVisible, "HUD should not be visible immediately")
+        // Expect timer scheduled for reveal while the prepared HUD remains invisible.
+        XCTAssertEqual(timerMock.scheduledTimers.count, 1, "Should schedule a timer for HUD reveal")
+        XCTAssertEqual(timerMock.scheduledTimers.last?.0 ?? -1, 0.2, accuracy: 0.001, "HUD reveal delay should stay short")
+        XCTAssertEqual(activationCount, 1, "Preparing the HUD should activate ShortcutCycle immediately")
+        XCTAssertTrue(manager.isSessionActive, "A prepared HUD session should be active immediately")
+        XCTAssertFalse(manager.isVisible, "HUD should remain invisible during the initial preparation window")
+        XCTAssertEqual(windowAlphaChanges.last, 0, "Prepared HUD should start fully transparent")
+        XCTAssertEqual(mouseInteractionStates.last, true, "Prepared HUD should ignore mouse interaction until revealed")
 
         // 2. Release immediately (simulated by not firing timer and ending session)
         manager.hide() // Simulate release/finalize
@@ -191,7 +225,9 @@ final class PressAndHoldTests: XCTestCase {
     }
 
     @MainActor
-    func testPressAndHoldShowsHUD() {
+    func testPressAndHoldShowsHUD() async {
+        manager.currentModifierFlags = { [.option] }
+
         // 1. Press Shortcut
         manager.scheduleShow(
             items: [HUDAppItem(bundleId: "com.test.1", name: "Test 1", icon: nil)],
@@ -208,13 +244,15 @@ final class PressAndHoldTests: XCTestCase {
 
         // 3. Fire Timer
         timerMock.fireLastTimer()
-
-        // The timer block calls presentHUD. In unit tests without a real window loop,
-        // we verify the timer was scheduled and fired — the delay mechanism is correct.
+        await Task.yield()
+        await Task.yield()
+        XCTAssertTrue(manager.isVisible, "Holding through the reveal delay should make the HUD visible")
+        XCTAssertEqual(windowAlphaChanges.last, 1, "Reveal should animate the HUD to full opacity")
+        XCTAssertEqual(mouseInteractionStates.last, false, "Revealed HUD should accept mouse interaction")
     }
 
     @MainActor
-    func testDelayedShowDefersActivationUntilHUDAppears() async {
+    func testDelayedShowPreparesInvisibleHUDBeforeReveal() async {
         manager.scheduleShow(
             items: [HUDAppItem(bundleId: "com.test.1", name: "Test 1", icon: nil)],
             activeAppId: "com.test.current",
@@ -223,17 +261,23 @@ final class PressAndHoldTests: XCTestCase {
             activeKey: .a
         )
 
-        XCTAssertEqual(activationCount, 0, "Delayed HUD path should not activate the app before the HUD appears")
-        XCTAssertTrue(globalMonitorMasks.contains(.flagsChanged), "Delayed HUD path should start with global modifier monitoring")
-        XCTAssertEqual(localMonitorMasks, [], "Delayed HUD path should not install local monitors before activation")
+        XCTAssertEqual(activationCount, 1, "Prepared HUD path should activate the app before the HUD is revealed")
+        XCTAssertTrue(manager.isSessionActive, "Prepared HUD session should be active immediately")
+        XCTAssertFalse(manager.isVisible, "HUD should stay invisible until the reveal timer fires")
+        XCTAssertTrue(globalMonitorMasks.contains(.flagsChanged), "Prepared HUD path should monitor global modifier releases")
+        XCTAssertTrue(localMonitorMasks.contains(.flagsChanged), "Prepared HUD path should also monitor local modifier releases")
+        XCTAssertEqual(windowAlphaChanges.last, 0, "Prepared HUD should stay transparent before reveal")
+        XCTAssertEqual(mouseInteractionStates.last, true, "Prepared HUD should ignore mouse interaction")
 
         timerMock.fireLastNonRepeatingTimer()
         await Task.yield()
         await Task.yield()
 
-        XCTAssertEqual(activationCount, 1, "Showing the HUD should activate the app exactly once")
-        XCTAssertTrue(localMonitorMasks.contains(.flagsChanged), "HUD presentation should switch to local modifier monitoring")
-        XCTAssertTrue(removedMonitorCount > 0, "Transitioning to the visible HUD should remove pre-show monitors")
+        XCTAssertTrue(manager.isVisible, "Reveal timer should transition the HUD into the visible state")
+        XCTAssertTrue(localMonitorMasks.contains(.flagsChanged), "Revealed HUD should keep local modifier monitoring")
+        XCTAssertTrue(removedMonitorCount > 0, "Transitioning to the revealed HUD should remove prepared-phase monitors")
+        XCTAssertEqual(windowAlphaChanges.last, 1, "Reveal should animate to full opacity")
+        XCTAssertEqual(mouseInteractionStates.last, false, "Revealed HUD should allow mouse interaction")
     }
 
     @MainActor
@@ -292,6 +336,64 @@ final class PressAndHoldTests: XCTestCase {
         )
 
         XCTAssertEqual(closeCount, 0)
+    }
+
+    @MainActor
+    func testVisibleBackgroundSettingsUsesTheSamePreparedDelayPath() {
+        let settingsWindow = MockWindow(
+            identifier: NSUserInterfaceItemIdentifier("settings"),
+            isVisible: true,
+            isOnActiveSpace: true
+        )
+
+        manager.isAppActive = { false }
+        manager.settingsWindowsProvider = { [settingsWindow] }
+
+        manager.scheduleShow(
+            items: [HUDAppItem(bundleId: "com.test.1", name: "Test 1", icon: nil)],
+            activeAppId: "com.test.current",
+            modifierFlags: [.option],
+            shortcut: "Opt+1",
+            activeKey: .a
+        )
+
+        XCTAssertEqual(timerMock.scheduledTimers.count, 1, "Background Settings should still use the standard reveal delay")
+        XCTAssertEqual(timerMock.scheduledTimers.last?.0 ?? -1, 0.2, accuracy: 0.001, "Reveal delay should stay unchanged with Settings visible")
+        XCTAssertEqual(activationCount, 1, "Prepared HUD path should still activate ShortcutCycle immediately")
+        XCTAssertFalse(manager.isVisible, "Background Settings should not force immediate visible HUD presentation")
+        XCTAssertTrue(globalMonitorMasks.contains(.flagsChanged), "Prepared HUD path should still use global release monitoring before reveal")
+    }
+
+    @MainActor
+    func testRepeatedInvocationBeforeRevealRevealsImmediately() {
+        manager.scheduleShow(
+            items: [
+                HUDAppItem(bundleId: "com.test.1", name: "Test 1", icon: nil),
+                HUDAppItem(bundleId: "com.test.2", name: "Test 2", icon: nil)
+            ],
+            activeAppId: "com.test.1",
+            modifierFlags: [.option],
+            shortcut: "Opt+1"
+        )
+
+        XCTAssertFalse(manager.isVisible)
+        XCTAssertTrue(manager.isSessionActive)
+
+        timeMock.currentTime = timeMock.currentTime.addingTimeInterval(0.1)
+
+        manager.scheduleShow(
+            items: [
+                HUDAppItem(bundleId: "com.test.1", name: "Test 1", icon: nil),
+                HUDAppItem(bundleId: "com.test.2", name: "Test 2", icon: nil)
+            ],
+            activeAppId: "com.test.2",
+            modifierFlags: [.option],
+            shortcut: "Opt+1"
+        )
+
+        XCTAssertTrue(manager.isVisible, "A repeated hit during the invisible preparation phase should reveal the HUD immediately")
+        XCTAssertEqual(windowAlphaChanges.last, 1, "Repeated hit should reveal the HUD to full opacity")
+        XCTAssertEqual(mouseInteractionStates.last, false, "Revealed HUD should allow mouse interaction")
     }
 
     @MainActor
@@ -404,6 +506,74 @@ final class PressAndHoldTests: XCTestCase {
     }
 
     @MainActor
+    func testBlindSwitchBeforeHUDPresentationCanFinalizeFromLocalFlagsMonitor() async throws {
+        let settingsWindow = MockWindow(
+            identifier: NSUserInterfaceItemIdentifier("settings"),
+            isVisible: true,
+            isOnActiveSpace: true
+        )
+        var closeCount = 0
+        var activateCount = 0
+
+        manager.settingsWindowsProvider = { [settingsWindow] }
+        manager.closeWindow = { _ in
+            closeCount += 1
+        }
+        manager.targetLeavesCurrentSpace = { _ in true }
+        manager.activatePendingTargetApp = { _ in
+            activateCount += 1
+        }
+
+        manager.scheduleShow(
+            items: [HUDAppItem(bundleId: "com.test.local-quick-target", pid: 25, name: "Local Quick Target")],
+            activeAppId: "com.test.local-quick-target::25",
+            modifierFlags: [.option],
+            shortcut: "Opt+1"
+        )
+
+        let flagsHandler = try XCTUnwrap(latestLocalMonitorHandler(for: .flagsChanged))
+        _ = flagsHandler(try makeFlagsChangedEvent(modifierFlags: []))
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(closeCount, 0)
+        XCTAssertEqual(activateCount, 1)
+    }
+
+    @MainActor
+    func testBlindSwitchBeforeHUDPresentationOrdersCurrentSpaceWindowsBackBeforeActivation() async throws {
+        let settingsWindow = MockWindow(
+            identifier: NSUserInterfaceItemIdentifier("settings"),
+            isVisible: true,
+            isOnActiveSpace: true
+        )
+        var events: [String] = []
+
+        manager.settingsWindowsProvider = { [settingsWindow] }
+        manager.appWindowsProvider = { [settingsWindow] }
+        manager.orderWindowBack = { _ in
+            events.append("back")
+        }
+        manager.activatePendingTargetApp = { _ in
+            events.append("activate")
+        }
+
+        manager.scheduleShow(
+            items: [HUDAppItem(bundleId: "com.test.back-target", pid: 26, name: "Back Target")],
+            activeAppId: "com.test.back-target::26",
+            modifierFlags: [.option],
+            shortcut: "Opt+1"
+        )
+
+        let flagsHandler = try XCTUnwrap(latestLocalMonitorHandler(for: .flagsChanged))
+        _ = flagsHandler(try makeFlagsChangedEvent(modifierFlags: []))
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertEqual(Array(events.prefix(2)), ["back", "activate"])
+    }
+
+    @MainActor
     func testHideClosesCurrentSpaceSettingsWhenSelectedTargetLeavesCurrentSpace() {
         let settingsWindow = MockWindow(
             identifier: NSUserInterfaceItemIdentifier("settings"),
@@ -509,8 +679,7 @@ final class PressAndHoldTests: XCTestCase {
         XCTAssertEqual(timerMock.scheduledTimers.count, 1)
 
         // 2. Release immediately (Session End)
-        // This MUST clear lastRequestTime
-        manager.lastRequestTime = nil // Simulating `finalizeSwitchAndHide` effect
+        manager.hide()
         timeMock.currentTime = timeMock.currentTime.addingTimeInterval(0.1) // 100ms later
         timerMock.scheduledTimers.removeAll()
 
@@ -522,10 +691,8 @@ final class PressAndHoldTests: XCTestCase {
             shortcut: "Opt+1"
         )
 
-        // If bug was present: `isRepeated` = true -> Show Immediate
-        // If fixed: `isRepeated` = false -> Schedule Timer
-
-        XCTAssertEqual(timerMock.scheduledTimers.count, 1, "Should schedule a delay timer, not show immediately")
+        XCTAssertEqual(timerMock.scheduledTimers.count, 1, "A new quick-tap session should schedule a fresh reveal timer")
+        XCTAssertFalse(manager.isVisible, "A new quick tap should not reveal the HUD immediately")
     }
 
     // MARK: - isLooping / Throttling Tests

--- a/ShortcutCycle/ShortcutCycleTests/PressAndHoldTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/PressAndHoldTests.swift
@@ -521,6 +521,35 @@ final class PressAndHoldTests: XCTestCase {
     }
 
     @MainActor
+    func testFinalizeRequiresAllConfiguredModifiersToRemainHeld() async throws {
+        var activateCount = 0
+
+        manager.currentModifierFlags = { [.command] }
+        manager.activatePendingTargetApp = { _ in
+            activateCount += 1
+        }
+
+        manager.scheduleShow(
+            items: [HUDAppItem(bundleId: "com.test.multi-mod", pid: 61, name: "Multi Mod Target")],
+            activeAppId: "com.test.multi-mod::61",
+            modifierFlags: [.command, .option],
+            shortcut: "Cmd+Opt+1",
+            immediate: true
+        )
+
+        XCTAssertTrue(manager.isVisible, "Immediate path should reveal the HUD before testing modifier release")
+
+        let flagsHandler = try XCTUnwrap(latestLocalMonitorHandler(for: .flagsChanged))
+        _ = flagsHandler(try makeFlagsChangedEvent(modifierFlags: [.command]))
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertFalse(manager.isSessionActive, "Dropping any required modifier should finalize the HUD session")
+        XCTAssertFalse(manager.isVisible, "HUD should hide once one of the required modifiers is released")
+        XCTAssertEqual(activateCount, 1, "Finalizing after a partial modifier release should still activate the pending target once")
+    }
+
+    @MainActor
     func testBlindSwitchBeforeHUDPresentationKeepsSettingsOpen() async throws {
         let settingsWindow = MockWindow(
             identifier: NSUserInterfaceItemIdentifier("settings"),


### PR DESCRIPTION
## Summary
- unify quick tap and visible HUD handling into a single two-phase HUD session
- prepare the HUD immediately as an invisible, non-interactive panel and reveal it after the existing hold delay
- treat a prepared HUD session as active for cycling logic so repeated hits before reveal still advance correctly

## Root cause
Issue #44 came from the blind-switch path and the visible-HUD path behaving differently. When the HUD was not shown yet, quick taps relied on a separate activation/release path, which made focus and window-order behavior unreliable in some Settings-window states.

This change removes that split by always going through the HUD session path:
- first phase: prepare and activate, but keep the HUD transparent and ignore mouse input
- second phase: reveal the HUD, enable interaction, and start auto-cycle timing from the reveal point

## User impact
- quick taps and holds now share the same activation flow
- the HUD should no longer behave differently depending on whether Settings is visible or frontmost
- repeated shortcut hits before the reveal delay now reveal and continue cycling immediately

## Validation
- `swift test --filter PressAndHoldTests`
- `swift test --filter AppSwitcherTests`
- `swift test`

Closes #44