### PR TITLE
[codex] Improve group settings feedback and navigation

### DIFF
--- a/ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj
+++ b/ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		017 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 901 /* KeyboardShortcuts */; };
 		A1B200022F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */; };
 		A1B200032F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */; };
+		C0A1D0012FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1D0002FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift */; };
+		C0A1D0022FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1D0002FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift */; };
 		DF88A3762F300B110042E749 /* HUDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3542F300B110042E749 /* HUDManager.swift */; };
 		DF88A3772F300B110042E749 /* ShortcutCycleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3742F300B110042E749 /* ShortcutCycleApp.swift */; };
 		DF88A3782F300B110042E749 /* GroupEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A36D2F300B110042E749 /* GroupEditView.swift */; };
@@ -97,6 +99,7 @@
 /* Begin PBXFileReference section */
 		100 /* ShortcutCycle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShortcutCycle.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutSuggestion.swift; sourceTree = "<group>"; };
+		C0A1D0002FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupSwitchPerformanceTracker.swift; sourceTree = "<group>"; };
 		DF88A3372F300B110042E749 /* String+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Localization.swift"; sourceTree = "<group>"; };
 		DF88A3392F300B110042E749 /* AppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroup.swift; sourceTree = "<group>"; };
 		DF88A33A2F300B110042E749 /* AppItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppItem.swift; sourceTree = "<group>"; };
@@ -261,10 +264,19 @@
 			path = Overlay;
 			sourceTree = "<group>";
 		};
+		C0A1D0032FB0000100C0DE01 /* Diagnostics */ = {
+			isa = PBXGroup;
+			children = (
+				C0A1D0002FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift */,
+			);
+			path = Diagnostics;
+			sourceTree = "<group>";
+		};
 		DF88A35D2F300B110042E749 /* Services */ = {
 			isa = PBXGroup;
 			children = (
 				DF88A3522F300B110042E749 /* AppSwitcher */,
+				C0A1D0032FB0000100C0DE01 /* Diagnostics */,
 				DF88A3552F300B110042E749 /* HUD */,
 				DF88A3572F300B110042E749 /* Managers */,
 				DF88A3592F300B110042E749 /* Overlay */,
@@ -529,6 +541,7 @@
 				DF88A3B92F300CB20042E749 /* HUDItemFilter.swift in Sources */,
 				A1B200022F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */,
 				DF88A39B2F300C800042E749 /* SettingsExport.swift in Sources */,
+				C0A1D0012FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift in Sources */,
 				DF88A39C2F300C800042E749 /* AppGroup.swift in Sources */,
 				DF88A3A62F300CA00042E749 /* LaunchAtLoginManager.swift in Sources */,
 				DF88A3A72F300CA00042E749 /* ShortcutManager.swift in Sources */,
@@ -585,6 +598,7 @@
 				DF88A3832F300B110042E749 /* HUDAppItem.swift in Sources */,
 				DF88A3BA2F300CB20042E749 /* HUDItemFilter.swift in Sources */,
 				A1B200032F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */,
+				C0A1D0022FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift in Sources */,
 				DF88A3842F300B110042E749 /* AppItem.swift in Sources */,
 				DF88A3852F300B110042E749 /* LaunchAtLoginManager.swift in Sources */,
 				DF88A3862F300B110042E749 /* MenuBarView.swift in Sources */,

--- a/ShortcutCycle/ShortcutCycle/Services/AppSwitcher/IconCache.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/AppSwitcher/IconCache.swift
@@ -8,7 +8,6 @@ class IconCache {
     static let shared = IconCache()
 
     private let lock = NSLock()
-    private let lookupQueue = DispatchQueue(label: "ShortcutCycle.IconCache", qos: .userInitiated)
     private var cache: [String: NSImage] = [:]
     private var failedLookups: Set<String> = []
     private var pendingCallbacks: [String: [(NSImage?) -> Void]] = [:]
@@ -31,7 +30,7 @@ class IconCache {
             return cached
         }
 
-        let icon = Self.resolveIcon(for: appItem)
+        let icon = Self.resolveIconOnMainThread(for: appItem)
 
         lock.lock()
         if let icon {
@@ -71,12 +70,9 @@ class IconCache {
 
         guard shouldStartLookup else { return }
 
-        lookupQueue.async { [appItem] in
+        DispatchQueue.main.async { [appItem] in
             let icon = Self.resolveIcon(for: appItem)
-
-            DispatchQueue.main.async {
-                self.finishLookup(for: key, icon: icon)
-            }
+            self.finishLookup(for: key, icon: icon)
         }
     }
 
@@ -99,6 +95,18 @@ class IconCache {
         for callback in callbacks {
             callback(icon)
         }
+    }
+
+    private static func resolveIconOnMainThread(for appItem: AppItem) -> NSImage? {
+        if Thread.isMainThread {
+            return resolveIcon(for: appItem)
+        }
+
+        var icon: NSImage?
+        DispatchQueue.main.sync {
+            icon = resolveIcon(for: appItem)
+        }
+        return icon
     }
 
     private static func resolveIcon(for appItem: AppItem) -> NSImage? {

--- a/ShortcutCycle/ShortcutCycle/Services/AppSwitcher/IconCache.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/AppSwitcher/IconCache.swift
@@ -6,37 +6,119 @@ import ShortcutCycleCore
 
 class IconCache {
     static let shared = IconCache()
-    
+
+    private let lock = NSLock()
+    private let lookupQueue = DispatchQueue(label: "ShortcutCycle.IconCache", qos: .userInitiated)
     private var cache: [String: NSImage] = [:]
-    
+    private var failedLookups: Set<String> = []
+    private var pendingCallbacks: [String: [(NSImage?) -> Void]] = [:]
+
     private init() {}
-    
+
+    func cachedIcon(for appItem: AppItem) -> NSImage? {
+        lock.lock()
+        defer { lock.unlock() }
+
+        if failedLookups.contains(appItem.bundleIdentifier) {
+            return nil
+        }
+
+        return cache[appItem.bundleIdentifier]
+    }
+
     func getIcon(for appItem: AppItem) -> NSImage? {
-        if let cached = cache[appItem.bundleIdentifier] {
+        if let cached = cachedIcon(for: appItem) {
             return cached
         }
-        
+
+        let icon = Self.resolveIcon(for: appItem)
+
+        lock.lock()
+        if let icon {
+            cache[appItem.bundleIdentifier] = icon
+            failedLookups.remove(appItem.bundleIdentifier)
+        } else {
+            failedLookups.insert(appItem.bundleIdentifier)
+        }
+        lock.unlock()
+
+        return icon
+    }
+
+    func loadIcon(for appItem: AppItem, completion: @escaping (NSImage?) -> Void) {
+        if let cached = cachedIcon(for: appItem) {
+            completion(cached)
+            return
+        }
+
+        let key = appItem.bundleIdentifier
+        var shouldStartLookup = false
+
+        lock.lock()
+        if failedLookups.contains(key) {
+            lock.unlock()
+            completion(nil)
+            return
+        }
+
+        if pendingCallbacks[key] != nil {
+            pendingCallbacks[key, default: []].append(completion)
+        } else {
+            pendingCallbacks[key] = [completion]
+            shouldStartLookup = true
+        }
+        lock.unlock()
+
+        guard shouldStartLookup else { return }
+
+        lookupQueue.async { [appItem] in
+            let icon = Self.resolveIcon(for: appItem)
+
+            DispatchQueue.main.async {
+                self.finishLookup(for: key, icon: icon)
+            }
+        }
+    }
+
+    func prefetchIcons(for apps: [AppItem]) {
+        for app in apps {
+            loadIcon(for: app) { _ in }
+        }
+    }
+
+    private func finishLookup(for key: String, icon: NSImage?) {
+        lock.lock()
+        if let icon {
+            cache[key] = icon
+        } else {
+            failedLookups.insert(key)
+        }
+        let callbacks = pendingCallbacks.removeValue(forKey: key) ?? []
+        lock.unlock()
+
+        for callback in callbacks {
+            callback(icon)
+        }
+    }
+
+    private static func resolveIcon(for appItem: AppItem) -> NSImage? {
         var icon: NSImage?
-        
+
         // Try to get icon from running app first (most accurate)
         if let runningApp = NSRunningApplication.runningApplications(withBundleIdentifier: appItem.bundleIdentifier).first {
             icon = runningApp.icon
         }
-        
+
         // Try path
         if icon == nil, let path = appItem.iconPath {
-             icon = NSWorkspace.shared.icon(forFile: path)
+            icon = NSWorkspace.shared.icon(forFile: path)
         }
-        
+
         // Try finding app by bundle ID
         if icon == nil, let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: appItem.bundleIdentifier) {
             icon = NSWorkspace.shared.icon(forFile: url.path)
         }
-        
-        if let icon = icon {
-            cache[appItem.bundleIdentifier] = icon
-        }
-        
+
         return icon
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Services/Diagnostics/GroupSwitchPerformanceTracker.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/Diagnostics/GroupSwitchPerformanceTracker.swift
@@ -1,0 +1,295 @@
+import Foundation
+import OSLog
+import os.signpost
+
+@MainActor
+final class GroupSwitchPerformanceTracker {
+    static let shared = GroupSwitchPerformanceTracker()
+
+    static let enabledDefaultsKey = "Debug.GroupSwitchPerformanceEnabled"
+
+    private struct Session {
+        let sequence: Int
+        let signpostID: OSSignpostID
+        let groupId: UUID
+        let source: String
+        let startedAtUptimeNanos: UInt64
+        let expectedGroupIconCount: Int
+        var headerVisibleAtUptimeNanos: UInt64?
+        var shortcutSectionVisibleAtUptimeNanos: UInt64?
+        var recorderMountedAtUptimeNanos: UInt64?
+        var appsSectionVisibleAtUptimeNanos: UInt64?
+        var quickAddRefreshStartedAtUptimeNanos: UInt64?
+        var quickAddReadyAtUptimeNanos: UInt64?
+        var firstGroupIconResolvedAtUptimeNanos: UInt64?
+        var allGroupIconsResolvedAtUptimeNanos: UInt64?
+        var resolvedGroupIconIDs: Set<UUID> = []
+    }
+
+    private let subsystem = Bundle.main.bundleIdentifier ?? "ShortcutCycle"
+    private lazy var logger = Logger(subsystem: subsystem, category: "GroupSwitchPerformance")
+    private lazy var signpostLog = OSLog(subsystem: subsystem, category: "GroupSwitchPerformance")
+    private var currentSession: Session?
+    private var nextSequence = 1
+
+    private init() {}
+
+    func beginGroupSwitch(
+        to groupId: UUID,
+        source: String,
+        expectedGroupIconCount: Int
+    ) {
+        guard isEnabled else { return }
+        guard currentSession?.groupId != groupId else { return }
+
+        finishCurrentSession(reason: "superseded")
+
+        let signpostID = OSSignpostID(log: signpostLog)
+        var session = Session(
+            sequence: nextSequence,
+            signpostID: signpostID,
+            groupId: groupId,
+            source: source,
+            startedAtUptimeNanos: nowUptimeNanos(),
+            expectedGroupIconCount: expectedGroupIconCount
+        )
+        nextSequence += 1
+
+        os_signpost(
+            .begin,
+            log: signpostLog,
+            name: "GroupSwitch",
+            signpostID: signpostID,
+            "sequence=%{public}d source=%{public}@ group=%{public}@ app_count=%{public}d",
+            session.sequence,
+            session.source as NSString,
+            session.groupId.uuidString as NSString,
+            session.expectedGroupIconCount
+        )
+
+        logger.notice(
+            "Group switch #\(session.sequence, privacy: .public) started source=\(session.source, privacy: .public) group=\(session.groupId.uuidString, privacy: .public) appCount=\(session.expectedGroupIconCount, privacy: .public)"
+        )
+
+        if expectedGroupIconCount == 0 {
+            session.allGroupIconsResolvedAtUptimeNanos = session.startedAtUptimeNanos
+            logEvent(
+                "all group-app icons resolved",
+                session: session,
+                elapsedNanos: 0,
+                extra: "count=0"
+            )
+        }
+
+        currentSession = session
+        maybeFinishCurrentSession()
+    }
+
+    func markHeaderVisible(for groupId: UUID) {
+        guard var session = currentSession, session.groupId == groupId else { return }
+        guard session.headerVisibleAtUptimeNanos == nil else { return }
+
+        let now = nowUptimeNanos()
+        session.headerVisibleAtUptimeNanos = now
+        currentSession = session
+
+        logEvent(
+            "header visible",
+            session: session,
+            elapsedNanos: now - session.startedAtUptimeNanos
+        )
+        maybeFinishCurrentSession()
+    }
+
+    func markShortcutSectionVisible(for groupId: UUID) {
+        guard var session = currentSession, session.groupId == groupId else { return }
+        guard session.shortcutSectionVisibleAtUptimeNanos == nil else { return }
+
+        let now = nowUptimeNanos()
+        session.shortcutSectionVisibleAtUptimeNanos = now
+        currentSession = session
+
+        logEvent(
+            "shortcut section visible",
+            session: session,
+            elapsedNanos: now - session.startedAtUptimeNanos
+        )
+        maybeFinishCurrentSession()
+    }
+
+    func markRecorderMounted(for groupId: UUID) {
+        guard var session = currentSession, session.groupId == groupId else { return }
+        guard session.recorderMountedAtUptimeNanos == nil else { return }
+
+        let now = nowUptimeNanos()
+        session.recorderMountedAtUptimeNanos = now
+        currentSession = session
+
+        logEvent(
+            "recorder mounted",
+            session: session,
+            elapsedNanos: now - session.startedAtUptimeNanos
+        )
+        maybeFinishCurrentSession()
+    }
+
+    func markAppsSectionVisible(for groupId: UUID) {
+        guard var session = currentSession, session.groupId == groupId else { return }
+        guard session.appsSectionVisibleAtUptimeNanos == nil else { return }
+
+        let now = nowUptimeNanos()
+        session.appsSectionVisibleAtUptimeNanos = now
+        currentSession = session
+
+        logEvent(
+            "apps section visible",
+            session: session,
+            elapsedNanos: now - session.startedAtUptimeNanos
+        )
+    }
+
+    func markQuickAddRefreshStarted(for groupId: UUID) {
+        guard var session = currentSession, session.groupId == groupId else { return }
+        guard session.quickAddRefreshStartedAtUptimeNanos == nil else { return }
+
+        let now = nowUptimeNanos()
+        session.quickAddRefreshStartedAtUptimeNanos = now
+        currentSession = session
+
+        logEvent(
+            "quick-add refresh started",
+            session: session,
+            elapsedNanos: now - session.startedAtUptimeNanos
+        )
+    }
+
+    func markQuickAddReady(for groupId: UUID, candidateCount: Int) {
+        guard var session = currentSession, session.groupId == groupId else { return }
+        guard session.quickAddReadyAtUptimeNanos == nil else { return }
+
+        let now = nowUptimeNanos()
+        session.quickAddReadyAtUptimeNanos = now
+        currentSession = session
+
+        logEvent(
+            "quick-add ready",
+            session: session,
+            elapsedNanos: now - session.startedAtUptimeNanos,
+            extra: "candidate_count=\(candidateCount)"
+        )
+        maybeFinishCurrentSession()
+    }
+
+    func markGroupIconResolved(itemId: UUID, for groupId: UUID) {
+        guard var session = currentSession, session.groupId == groupId else { return }
+        guard session.expectedGroupIconCount > 0 else { return }
+        guard session.resolvedGroupIconIDs.insert(itemId).inserted else { return }
+
+        let now = nowUptimeNanos()
+        if session.firstGroupIconResolvedAtUptimeNanos == nil {
+            session.firstGroupIconResolvedAtUptimeNanos = now
+            logEvent(
+                "first group-app icon resolved",
+                session: session,
+                elapsedNanos: now - session.startedAtUptimeNanos
+            )
+        }
+
+        if session.resolvedGroupIconIDs.count >= session.expectedGroupIconCount,
+           session.allGroupIconsResolvedAtUptimeNanos == nil {
+            session.allGroupIconsResolvedAtUptimeNanos = now
+            logEvent(
+                "all group-app icons resolved",
+                session: session,
+                elapsedNanos: now - session.startedAtUptimeNanos,
+                extra: "count=\(session.expectedGroupIconCount)"
+            )
+        }
+
+        currentSession = session
+        maybeFinishCurrentSession()
+    }
+
+    private var isEnabled: Bool {
+        if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
+            return false
+        }
+
+#if DEBUG
+        return UserDefaults.standard.object(forKey: Self.enabledDefaultsKey) as? Bool ?? true
+#else
+        return UserDefaults.standard.bool(forKey: Self.enabledDefaultsKey)
+#endif
+    }
+
+    private func maybeFinishCurrentSession() {
+        guard
+            let session = currentSession,
+            session.recorderMountedAtUptimeNanos != nil,
+            session.quickAddReadyAtUptimeNanos != nil
+        else {
+            return
+        }
+
+        finishCurrentSession(reason: "completed")
+    }
+
+    private func finishCurrentSession(reason: String) {
+        guard let session = currentSession else { return }
+
+        let end = nowUptimeNanos()
+        let totalMilliseconds = milliseconds(from: session.startedAtUptimeNanos, to: end)
+        os_signpost(
+            .end,
+            log: signpostLog,
+            name: "GroupSwitch",
+            signpostID: session.signpostID,
+            "sequence=%{public}d reason=%{public}@ total_ms=%{public}.2f",
+            session.sequence,
+            reason as NSString,
+            totalMilliseconds
+        )
+
+        logger.notice(
+            "Group switch #\(session.sequence, privacy: .public) finished reason=\(reason, privacy: .public) total=\(self.formatMilliseconds(totalMilliseconds), privacy: .public)ms"
+        )
+        currentSession = nil
+    }
+
+    private func logEvent(
+        _ name: StaticString,
+        session: Session,
+        elapsedNanos: UInt64,
+        extra: String? = nil
+    ) {
+        let elapsedMilliseconds = Double(elapsedNanos) / 1_000_000
+        let extraString = extra.map { " \($0)" } ?? ""
+
+        os_signpost(
+            .event,
+            log: signpostLog,
+            name: name,
+            signpostID: session.signpostID,
+            "sequence=%{public}d elapsed_ms=%{public}.2f extra=%{public}@",
+            session.sequence,
+            elapsedMilliseconds,
+            extraString as NSString
+        )
+
+        logger.debug(
+            "Group switch #\(session.sequence, privacy: .public) \(String(describing: name), privacy: .public) at \(self.formatMilliseconds(elapsedMilliseconds), privacy: .public)ms\(extraString, privacy: .public)"
+        )
+    }
+
+    private func nowUptimeNanos() -> UInt64 {
+        DispatchTime.now().uptimeNanoseconds
+    }
+
+    private func milliseconds(from start: UInt64, to end: UInt64) -> Double {
+        Double(end - start) / 1_000_000
+    }
+
+    private func formatMilliseconds(_ value: Double) -> String {
+        String(format: "%.2f", value)
+    }
+}

--- a/ShortcutCycle/ShortcutCycle/Services/Diagnostics/GroupSwitchPerformanceTracker.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/Diagnostics/GroupSwitchPerformanceTracker.swift
@@ -1,4 +1,5 @@
 import Foundation
+#if DEBUG
 import OSLog
 import os.signpost
 
@@ -215,11 +216,7 @@ final class GroupSwitchPerformanceTracker {
             return false
         }
 
-#if DEBUG
         return UserDefaults.standard.object(forKey: Self.enabledDefaultsKey) as? Bool ?? true
-#else
-        return UserDefaults.standard.bool(forKey: Self.enabledDefaultsKey)
-#endif
     }
 
     private func maybeFinishCurrentSession() {
@@ -293,3 +290,21 @@ final class GroupSwitchPerformanceTracker {
         String(format: "%.2f", value)
     }
 }
+#else
+@MainActor
+final class GroupSwitchPerformanceTracker {
+    static let shared = GroupSwitchPerformanceTracker()
+    static let enabledDefaultsKey = "Debug.GroupSwitchPerformanceEnabled"
+
+    private init() {}
+
+    func beginGroupSwitch(to groupId: UUID, source: String, expectedGroupIconCount: Int) {}
+    func markHeaderVisible(for groupId: UUID) {}
+    func markShortcutSectionVisible(for groupId: UUID) {}
+    func markRecorderMounted(for groupId: UUID) {}
+    func markAppsSectionVisible(for groupId: UUID) {}
+    func markQuickAddRefreshStarted(for groupId: UUID) {}
+    func markQuickAddReady(for groupId: UUID, candidateCount: Int) {}
+    func markGroupIconResolved(itemId: UUID, for groupId: UUID) {}
+}
+#endif

--- a/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
+++ b/ShortcutCycle/ShortcutCycle/ShortcutCycleApp.swift
@@ -184,11 +184,24 @@ struct AppCommands: Commands {
         guard store.groups.count >= 2 else { return }
         guard let currentId = store.selectedGroupId,
               let currentIndex = store.groups.firstIndex(where: { $0.id == currentId }) else {
-            store.selectedGroupId = store.groups.first?.id
+            if let firstGroup = store.groups.first {
+                GroupSwitchPerformanceTracker.shared.beginGroupSwitch(
+                    to: firstGroup.id,
+                    source: "command-previous",
+                    expectedGroupIconCount: firstGroup.apps.count
+                )
+                store.selectedGroupId = firstGroup.id
+            }
             return
         }
         let previousIndex = currentIndex == 0 ? store.groups.count - 1 : currentIndex - 1
-        store.selectedGroupId = store.groups[previousIndex].id
+        let previousGroup = store.groups[previousIndex]
+        GroupSwitchPerformanceTracker.shared.beginGroupSwitch(
+            to: previousGroup.id,
+            source: "command-previous",
+            expectedGroupIconCount: previousGroup.apps.count
+        )
+        store.selectedGroupId = previousGroup.id
     }
 
     private func selectNextGroup() {
@@ -196,11 +209,24 @@ struct AppCommands: Commands {
         guard store.groups.count >= 2 else { return }
         guard let currentId = store.selectedGroupId,
               let currentIndex = store.groups.firstIndex(where: { $0.id == currentId }) else {
-            store.selectedGroupId = store.groups.first?.id
+            if let firstGroup = store.groups.first {
+                GroupSwitchPerformanceTracker.shared.beginGroupSwitch(
+                    to: firstGroup.id,
+                    source: "command-next",
+                    expectedGroupIconCount: firstGroup.apps.count
+                )
+                store.selectedGroupId = firstGroup.id
+            }
             return
         }
         let nextIndex = currentIndex == store.groups.count - 1 ? 0 : currentIndex + 1
-        store.selectedGroupId = store.groups[nextIndex].id
+        let nextGroup = store.groups[nextIndex]
+        GroupSwitchPerformanceTracker.shared.beginGroupSwitch(
+            to: nextGroup.id,
+            source: "command-next",
+            expectedGroupIconCount: nextGroup.apps.count
+        )
+        store.selectedGroupId = nextGroup.id
     }
 
     private func moveSelectedGroup(by delta: Int) {

--- a/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/AppDropZoneView.swift
@@ -2,17 +2,25 @@ import SwiftUI
 #if canImport(ShortcutCycleCore)
 import ShortcutCycleCore
 #endif
+import AppKit
 import UniformTypeIdentifiers
 
 struct AppIconThumbnailView: View {
     let app: AppItem
     let size: CGFloat
     let fallbackFontSize: CGFloat
+    let onIconResolved: (() -> Void)?
+    @State private var icon: NSImage?
+    @State private var hasReportedResolution = false
+
+    private var displayedIcon: NSImage? {
+        icon ?? IconCache.shared.cachedIcon(for: app)
+    }
 
     var body: some View {
         Group {
-            if let icon = IconCache.shared.getIcon(for: app) {
-                Image(nsImage: icon)
+            if let displayedIcon {
+                Image(nsImage: displayedIcon)
                     .resizable()
                     .frame(width: size, height: size)
             } else {
@@ -22,6 +30,32 @@ struct AppIconThumbnailView: View {
                     .frame(width: size, height: size)
             }
         }
+        .task(id: app.id) {
+            hasReportedResolution = false
+            loadIconIfNeeded()
+        }
+    }
+
+    @MainActor
+    private func loadIconIfNeeded() {
+        if let cachedIcon = IconCache.shared.cachedIcon(for: app) {
+            icon = cachedIcon
+            reportResolutionIfNeeded()
+            return
+        }
+
+        icon = nil
+        IconCache.shared.loadIcon(for: app) { loadedIcon in
+            icon = loadedIcon
+            reportResolutionIfNeeded()
+        }
+    }
+
+    @MainActor
+    private func reportResolutionIfNeeded() {
+        guard !hasReportedResolution else { return }
+        hasReportedResolution = true
+        onIconResolved?()
     }
 }
 
@@ -33,7 +67,7 @@ struct AppRowView: View {
     
     var body: some View {
         HStack(spacing: 12) {
-            AppIconThumbnailView(app: app, size: 32, fallbackFontSize: 24)
+            AppIconThumbnailView(app: app, size: 32, fallbackFontSize: 24, onIconResolved: nil)
             
             VStack(alignment: .leading, spacing: 2) {
                 Text(app.name)
@@ -76,19 +110,26 @@ struct AppGridItemView: View {
     let app: AppItem
     let isPlaceholder: Bool
     let onDelete: () -> Void
+    let onIconResolved: (() -> Void)?
     @Environment(\.colorScheme) private var colorScheme
     @State private var isHovered = false
 
-    init(app: AppItem, isPlaceholder: Bool = false, onDelete: @escaping () -> Void) {
+    init(
+        app: AppItem,
+        isPlaceholder: Bool = false,
+        onDelete: @escaping () -> Void,
+        onIconResolved: (() -> Void)? = nil
+    ) {
         self.app = app
         self.isPlaceholder = isPlaceholder
         self.onDelete = onDelete
+        self.onIconResolved = onIconResolved
     }
     
     var body: some View {
         VStack(spacing: 8) {
             ZStack(alignment: .topTrailing) {
-                AppIconThumbnailView(app: app, size: 56, fallbackFontSize: 42)
+                AppIconThumbnailView(app: app, size: 56, fallbackFontSize: 42, onIconResolved: onIconResolved)
 
                 if isHovered && !isPlaceholder {
                     Button(action: onDelete) {

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -228,7 +228,8 @@ struct GroupEditView: View {
                     }
                 }
                 .padding(.vertical, 8)
-                .animation(.default, value: displayedApps)
+                // Only animate the temporary drag preview; switching groups should update immediately.
+                .animation(.default, value: dragPreviewApps?.map(\.id) ?? [])
             }
 
             addAppsPanel(for: group, quickAddCandidates: quickAddCandidates)
@@ -448,7 +449,7 @@ private struct GroupShortcutEditor: View {
             VStack(alignment: .leading, spacing: 8) {
                 KeyboardShortcuts.Recorder(for: shortcutName, onChange: handleShortcutChange)
                     .padding(.leading, 4)
-                    .id(selectedLanguage) // Recreate on language change so placeholder re-reads AppleLanguages
+                    .id("\(selectedLanguage)-\(groupId.uuidString)") // Recreate only when localization or target group changes
 
                 if shouldShowSuggestions {
                     ShortcutSuggestionRow(

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -17,7 +17,7 @@ struct GroupEditView: View {
     @State private var groupName: String = ""
     @State private var draggingApp: AppItem?
     @State private var dragPreviewApps: [AppItem]?
-    @State private var isHovering: Bool = false
+    @State private var isNameFieldHovered: Bool = false
     @FocusState private var isNameFocused: Bool
     @State private var suppressAutoFocus = true
     @State private var quickAddCandidates: [AppItem] = []
@@ -110,18 +110,23 @@ struct GroupEditView: View {
                 .padding(.vertical, 4)
                 .padding(.horizontal, 8)
                 .background(
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill((isHovering || isNameFocused) ? SettingsChromePalette.inlineFill(for: colorScheme) : Color.clear)
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(nameFieldBackgroundColor)
                 )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 6)
-                        .stroke(
-                            ((isHovering || isNameFocused) && colorScheme == .dark) ? SettingsChromePalette.panelBorder(for: colorScheme) : Color.clear,
-                            lineWidth: 1
-                        )
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(nameFieldBorderColor, lineWidth: nameFieldBorderWidth)
                 )
+                .shadow(
+                    color: nameFieldGlowColor,
+                    radius: nameFieldGlowRadius,
+                    x: 0,
+                    y: 0
+                )
+                .animation(.easeInOut(duration: 0.15), value: isNameFocused)
+                .animation(.easeInOut(duration: 0.15), value: isNameFieldHovered)
                 .onHover { hovering in
-                    isHovering = hovering
+                    isNameFieldHovered = hovering
                 }
                 .onChange(of: groupName) { _, newValue in
                     guard isNameFocused else { return }
@@ -130,6 +135,54 @@ struct GroupEditView: View {
                     store.updateGroup(updatedGroup)
                 }
         }
+    }
+
+    private var nameFieldBackgroundColor: Color {
+        if isNameFocused {
+            return SettingsChromePalette.focusRingFill(for: colorScheme)
+        }
+
+        if isNameFieldHovered {
+            return SettingsChromePalette.hoverRingFill(for: colorScheme)
+        }
+
+        return .clear
+    }
+
+    private var nameFieldBorderColor: Color {
+        if isNameFocused {
+            return SettingsChromePalette.focusRingBorder(for: colorScheme)
+        }
+
+        if isNameFieldHovered {
+            return SettingsChromePalette.hoverRingBorder(for: colorScheme)
+        }
+
+        return .clear
+    }
+
+    private var nameFieldBorderWidth: CGFloat {
+        isNameFocused ? 1.5 : (isNameFieldHovered ? 1 : 0)
+    }
+
+    private var nameFieldGlowColor: Color {
+        if isNameFocused {
+            return SettingsChromePalette.focusRingGlow(for: colorScheme)
+        }
+
+        if isNameFieldHovered {
+            return SettingsChromePalette.hoverRingGlow(for: colorScheme)
+        }
+
+        return .clear
+    }
+
+    private var nameFieldGlowRadius: CGFloat {
+        if isNameFocused {
+            return 8
+        }
+
+        return isNameFieldHovered ? 4 : 0
     }
 
     private func appsSection(for group: AppGroup) -> some View {

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -20,7 +20,11 @@ struct GroupEditView: View {
     @State private var isNameFieldHovered: Bool = false
     @FocusState private var isNameFocused: Bool
     @State private var suppressAutoFocus = true
+    @State private var areSecondarySectionsMounted = false
     @State private var quickAddCandidates: [AppItem] = []
+    @State private var isRefreshingQuickAddCandidates = false
+    @State private var secondarySectionsMountTask: Task<Void, Never>?
+    @State private var quickAddRefreshTask: Task<Void, Never>?
 
     init(
         groupId: UUID,
@@ -64,13 +68,25 @@ struct GroupEditView: View {
         }
         .onChange(of: (group?.apps.map(\.bundleIdentifier).sorted()) ?? []) { _, _ in
             dragPreviewApps = nil
-            refreshQuickAddCandidates()
+            if areSecondarySectionsMounted {
+                scheduleQuickAddCandidatesRefresh()
+            }
         }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didLaunchApplicationNotification)) { _ in
-            refreshQuickAddCandidates()
+            RunningAppQuickAddCatalog.shared.refresh()
+            if areSecondarySectionsMounted {
+                scheduleQuickAddCandidatesRefresh()
+            }
         }
         .onReceive(NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didTerminateApplicationNotification)) { _ in
-            refreshQuickAddCandidates()
+            RunningAppQuickAddCatalog.shared.refresh()
+            if areSecondarySectionsMounted {
+                scheduleQuickAddCandidatesRefresh()
+            }
+        }
+        .onDisappear {
+            secondarySectionsMountTask?.cancel()
+            quickAddRefreshTask?.cancel()
         }
     }
 
@@ -82,11 +98,18 @@ struct GroupEditView: View {
 
                 SettingsSectionDivider()
 
-                GroupShortcutEditor(group: group, groupId: groupId)
+                GroupShortcutEditor(
+                    group: group,
+                    groupId: groupId
+                )
 
                 SettingsSectionDivider()
 
-                appsSection(for: group)
+                if areSecondarySectionsMounted {
+                    appsSection(for: group)
+                } else {
+                    secondarySectionsPlaceholder
+                }
 
                 Spacer()
             }
@@ -134,6 +157,9 @@ struct GroupEditView: View {
                     updatedGroup.name = newValue
                     store.updateGroup(updatedGroup)
                 }
+        }
+        .task(id: groupId) {
+            GroupSwitchPerformanceTracker.shared.markHeaderVisible(for: groupId)
         }
     }
 
@@ -210,10 +236,14 @@ struct GroupEditView: View {
                     ForEach(displayedApps) { app in
                         AppGridItemView(
                             app: app,
-                            isPlaceholder: draggingApp?.id == app.id
-                        ) {
-                            store.removeApp(app, from: groupId)
-                        }
+                            isPlaceholder: draggingApp?.id == app.id,
+                            onDelete: {
+                                store.removeApp(app, from: groupId)
+                            },
+                            onIconResolved: {
+                                GroupSwitchPerformanceTracker.shared.markGroupIconResolved(itemId: app.id, for: groupId)
+                            }
+                        )
                         .onDrag {
                             draggingApp = app
                             return NSItemProvider(object: app.id.uuidString as NSString)
@@ -232,11 +262,43 @@ struct GroupEditView: View {
                 .animation(.default, value: dragPreviewApps?.map(\.id) ?? [])
             }
 
-            addAppsPanel(for: group, quickAddCandidates: quickAddCandidates)
+            addAppsPanel(
+                for: group,
+                quickAddCandidates: quickAddCandidates,
+                isRefreshingQuickAddCandidates: isRefreshingQuickAddCandidates
+            )
+        }
+        .task(id: groupId) {
+            GroupSwitchPerformanceTracker.shared.markAppsSectionVisible(for: groupId)
         }
     }
 
-    private func addAppsPanel(for group: AppGroup, quickAddCandidates: [AppItem]) -> some View {
+    private var secondarySectionsPlaceholder: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Applications".localized(language: selectedLanguage))
+                .font(.headline)
+
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(SettingsChromePalette.panelBackground(for: colorScheme))
+                .frame(maxWidth: .infinity)
+                .frame(height: 160)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(SettingsChromePalette.panelBorder(for: colorScheme), lineWidth: 1)
+                )
+                .overlay {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func addAppsPanel(
+        for group: AppGroup,
+        quickAddCandidates: [AppItem],
+        isRefreshingQuickAddCandidates: Bool
+    ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Add Apps".localized(language: selectedLanguage))
                 .font(.caption.weight(.semibold))
@@ -266,6 +328,11 @@ struct GroupEditView: View {
                         runningAppsOptionCard(quickAddCandidates)
                         browseAppsOptionCard(for: group)
                     }
+                }
+            } else if isRefreshingQuickAddCandidates {
+                VStack(alignment: .leading, spacing: 12) {
+                    runningAppsLoadingCard()
+                    browseAppsOptionCard(for: group)
                 }
             } else {
                 browseAppsOptionCard(for: group)
@@ -303,6 +370,19 @@ struct GroupEditView: View {
         }
     }
 
+    private func runningAppsLoadingCard() -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Running Apps".localized(language: selectedLanguage))
+                .font(.caption.weight(.medium))
+                .foregroundColor(.secondary)
+
+            ProgressView()
+                .controlSize(.small)
+                .padding(.vertical, 6)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
     private func browseAppsOptionCard(for group: AppGroup) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Browse or drag from Finder".localized(language: selectedLanguage))
@@ -316,41 +396,114 @@ struct GroupEditView: View {
     }
 
     private func loadGroupData() {
+        scheduleSecondarySectionsMount()
+
         if let group = group {
             groupName = group.name
+            IconCache.shared.prefetchIcons(for: group.apps)
         }
         dragPreviewApps = nil
-        refreshQuickAddCandidates()
+        quickAddRefreshTask?.cancel()
+        quickAddCandidates = []
+        isRefreshingQuickAddCandidates = false
     }
 
-    private func refreshQuickAddCandidates() {
+    private func scheduleSecondarySectionsMount() {
+        secondarySectionsMountTask?.cancel()
+        areSecondarySectionsMounted = false
+
+        guard group != nil else { return }
+
+        secondarySectionsMountTask = Task { @MainActor in
+            await Task.yield()
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+            areSecondarySectionsMounted = true
+            scheduleQuickAddCandidatesRefresh()
+        }
+    }
+
+    private func scheduleQuickAddCandidatesRefresh() {
+        quickAddRefreshTask?.cancel()
+
         guard let group else {
             quickAddCandidates = []
+            isRefreshingQuickAddCandidates = false
             return
         }
 
-        quickAddCandidates = runningAppCandidatesProvider(group.apps)
+        let groupApps = group.apps
+        quickAddCandidates = []
+        isRefreshingQuickAddCandidates = true
+        GroupSwitchPerformanceTracker.shared.markQuickAddRefreshStarted(for: groupId)
+
+        quickAddRefreshTask = Task { @MainActor in
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+
+            let candidates = runningAppCandidatesProvider(groupApps)
+            guard !Task.isCancelled else { return }
+
+            quickAddCandidates = candidates
+            isRefreshingQuickAddCandidates = false
+            IconCache.shared.prefetchIcons(for: candidates)
+            GroupSwitchPerformanceTracker.shared.markQuickAddReady(for: groupId, candidateCount: candidates.count)
+        }
     }
 
     private static func defaultRunningAppCandidates(for groupApps: [AppItem]) -> [AppItem] {
-        let runningApps: [RunningAppQuickAddSource] = NSWorkspace.shared.runningApplications.compactMap { app in
-            guard let bundleIdentifier = app.bundleIdentifier else { return nil }
-            return RunningAppQuickAddSource(
-                bundleIdentifier: bundleIdentifier,
-                bundleURL: app.bundleURL ?? NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier),
-                isRegularApp: app.activationPolicy == .regular
-            )
-        }
-        let excludedBundleIdentifiers = Set(["com.xcv58.ShortcutCycle", Bundle.main.bundleIdentifier].compactMap { $0 })
-        return RunningAppQuickAdd.candidates(
-            for: groupApps,
-            runningApps: runningApps,
-            excludedBundleIdentifiers: excludedBundleIdentifiers
-        )
+        RunningAppQuickAddCatalog.shared.candidates(for: groupApps)
     }
 
     static func shouldShowRunningAppQuickAddSection(_ quickAddCandidates: [AppItem]) -> Bool {
         !quickAddCandidates.isEmpty
+    }
+}
+
+@MainActor
+private final class RunningAppQuickAddCatalog {
+    static let shared = RunningAppQuickAddCatalog()
+
+    private var cachedApps: [AppItem] = []
+    private var hasLoaded = false
+
+    private init() {}
+
+    func refresh() {
+        let excludedBundleIdentifiers = Set(["com.xcv58.ShortcutCycle", Bundle.main.bundleIdentifier].compactMap { $0 })
+        var seenBundleIdentifiers = Set<String>()
+
+        cachedApps = NSWorkspace.shared.runningApplications.compactMap { app in
+            guard app.activationPolicy == .regular else { return nil }
+            guard let bundleIdentifier = app.bundleIdentifier else { return nil }
+            guard !excludedBundleIdentifiers.contains(bundleIdentifier) else { return nil }
+            guard seenBundleIdentifiers.insert(bundleIdentifier).inserted else { return nil }
+            guard let appURL = app.bundleURL ?? NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) else {
+                return nil
+            }
+            return AppItem.from(appURL: appURL)
+        }
+        .sorted { lhs, rhs in
+            let lhsKey = lhs.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            let rhsKey = rhs.name.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+
+            if lhsKey == rhsKey {
+                return lhs.bundleIdentifier < rhs.bundleIdentifier
+            }
+
+            return lhsKey < rhsKey
+        }
+
+        hasLoaded = true
+    }
+
+    func candidates(for groupApps: [AppItem]) -> [AppItem] {
+        if !hasLoaded {
+            refresh()
+        }
+
+        let excludedBundleIdentifiers = Set(groupApps.map(\.bundleIdentifier))
+        return cachedApps.filter { !excludedBundleIdentifiers.contains($0.bundleIdentifier) }
     }
 }
 
@@ -366,7 +519,7 @@ private struct RunningAppQuickAddButton: View {
         Button(action: onAdd) {
             VStack(spacing: 6) {
                 ZStack(alignment: .topTrailing) {
-                    AppIconThumbnailView(app: app, size: 30, fallbackFontSize: 24)
+                    AppIconThumbnailView(app: app, size: 30, fallbackFontSize: 24, onIconResolved: nil)
 
                     Image(systemName: "plus.circle.fill")
                         .font(.system(size: 12, weight: .semibold))
@@ -450,6 +603,9 @@ private struct GroupShortcutEditor: View {
                 KeyboardShortcuts.Recorder(for: shortcutName, onChange: handleShortcutChange)
                     .padding(.leading, 4)
                     .id("\(selectedLanguage)-\(groupId.uuidString)") // Recreate only when localization or target group changes
+                    .task(id: groupId) {
+                        GroupSwitchPerformanceTracker.shared.markRecorderMounted(for: groupId)
+                    }
 
                 if shouldShowSuggestions {
                     ShortcutSuggestionRow(
@@ -493,6 +649,9 @@ private struct GroupShortcutEditor: View {
             .font(.caption)
             .foregroundColor(.secondary)
             .padding(.top, 2)
+        }
+        .task(id: groupId) {
+            GroupSwitchPerformanceTracker.shared.markShortcutSectionVisible(for: groupId)
         }
     }
 

--- a/ShortcutCycle/ShortcutCycle/Views/GroupListView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupListView.swift
@@ -8,34 +8,17 @@ import KeyboardShortcuts
 struct GroupListView: View {
     @EnvironmentObject var store: GroupStore
     @Environment(\.colorScheme) private var colorScheme
+    let selection: Binding<UUID?>
     @State private var newGroupName = ""
     @State private var groupToRename: AppGroup?
     @State private var renameText = ""
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     @FocusState private var isInputFocused: Bool
 
-    /// A deferred-write binding for the List selection.
-    ///
-    /// NSTableView (backing List) can fire its selection-changed callback synchronously
-    /// during its layout pass when .scrollContentBackground(.hidden) causes a re-layout.
-    /// Writing to a @Published property during SwiftUI's render/commit phase fires
-    /// objectWillChange synchronously, which AttributeGraph detects as a cycle. Deferring
-    /// the write via Task breaks the synchronous path while preserving selection behavior.
-    private var selectedGroupIdBinding: Binding<UUID?> {
-        Binding(
-            get: { store.selectedGroupId },
-            set: { newValue in
-                Task { @MainActor in
-                    store.selectedGroupId = newValue
-                }
-            }
-        )
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             // Groups list
-            List(selection: selectedGroupIdBinding) {
+            List(selection: selection) {
                 ForEach(store.groups) { group in
                     GroupRowView(group: group)
                         .tag(group.id)
@@ -226,7 +209,7 @@ struct GroupRowView: View {
 }
 
 #Preview {
-    GroupListView()
+    GroupListView(selection: .constant(GroupStore.shared.selectedGroupId))
         .environmentObject(GroupStore.shared)
         .frame(width: 250, height: 400)
 }

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
@@ -131,6 +131,7 @@ struct GroupSettingsView: View {
     @EnvironmentObject var store: GroupStore
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     @Environment(\.colorScheme) private var colorScheme
+    @State private var pendingSelectedGroupId: UUID?
 
     /// A deferred-write binding for columnVisibility.
     ///
@@ -151,14 +152,43 @@ struct GroupSettingsView: View {
         )
     }
 
+    /// Keep the UI responsive by showing a temporary local selection immediately while
+    /// still deferring the store write that previously avoided an AttributeGraph cycle.
+    private var selectedGroupIdBinding: Binding<UUID?> {
+        Binding(
+            get: { pendingSelectedGroupId ?? store.selectedGroupId },
+            set: { newValue in
+                guard store.selectedGroupId != newValue else {
+                    pendingSelectedGroupId = nil
+                    return
+                }
+
+                pendingSelectedGroupId = newValue
+
+                Task { @MainActor in
+                    if store.selectedGroupId != newValue {
+                        store.selectedGroupId = newValue
+                    }
+
+                    if pendingSelectedGroupId == newValue {
+                        pendingSelectedGroupId = nil
+                    }
+                }
+            }
+        )
+    }
+
+    private var visibleSelectedGroupId: UUID? {
+        pendingSelectedGroupId ?? store.selectedGroupId
+    }
+
     var body: some View {
         NavigationSplitView(columnVisibility: columnVisibilityBinding) {
-            GroupListView()
+            GroupListView(selection: selectedGroupIdBinding)
                 .frame(minWidth: 220)
         } detail: {
-            if let selectedId = store.selectedGroupId {
+            if let selectedId = visibleSelectedGroupId {
                 GroupEditView(groupId: selectedId)
-                    .id(selectedId)
             } else {
                 ContentUnavailableView {
                     Label("No Group Selected".localized(language: selectedLanguage), systemImage: "folder")
@@ -179,5 +209,9 @@ struct GroupSettingsView: View {
         }
         .navigationTitle("App Groups".localized(language: selectedLanguage))
         .background(SettingsChromePalette.windowBackground(for: colorScheme))
+        .onChange(of: store.selectedGroupId) { _, _ in
+            // External selection changes (menu commands, URL routing, etc.) should win immediately.
+            pendingSelectedGroupId = nil
+        }
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
@@ -163,6 +163,14 @@ struct GroupSettingsView: View {
                     return
                 }
 
+                if let newValue {
+                    GroupSwitchPerformanceTracker.shared.beginGroupSwitch(
+                        to: newValue,
+                        source: "sidebar",
+                        expectedGroupIconCount: appCount(for: newValue)
+                    )
+                }
+
                 pendingSelectedGroupId = newValue
 
                 Task { @MainActor in
@@ -180,6 +188,11 @@ struct GroupSettingsView: View {
 
     private var visibleSelectedGroupId: UUID? {
         pendingSelectedGroupId ?? store.selectedGroupId
+    }
+
+    private func appCount(for groupId: UUID?) -> Int {
+        guard let groupId else { return 0 }
+        return store.groups.first(where: { $0.id == groupId })?.apps.count ?? 0
     }
 
     var body: some View {
@@ -212,6 +225,15 @@ struct GroupSettingsView: View {
         .onChange(of: store.selectedGroupId) { _, _ in
             // External selection changes (menu commands, URL routing, etc.) should win immediately.
             pendingSelectedGroupId = nil
+        }
+        .onChange(of: store.selectedGroupId) { _, newValue in
+            if let newValue {
+                GroupSwitchPerformanceTracker.shared.beginGroupSwitch(
+                    to: newValue,
+                    source: "external",
+                    expectedGroupIconCount: appCount(for: newValue)
+                )
+            }
         }
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
@@ -74,6 +74,42 @@ enum SettingsChromePalette {
             ? Color(nsColor: .quaternaryLabelColor).opacity(0.72)
             : Color.gray.opacity(0.30)
     }
+
+    static func focusRingFill(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color.accentColor.opacity(0.18)
+            : Color.accentColor.opacity(0.10)
+    }
+
+    static func focusRingBorder(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color.accentColor.opacity(0.95)
+            : Color.accentColor.opacity(0.65)
+    }
+
+    static func focusRingGlow(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color.accentColor.opacity(0.30)
+            : Color.accentColor.opacity(0.16)
+    }
+
+    static func hoverRingFill(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color.accentColor.opacity(0.10)
+            : inlineFill(for: colorScheme)
+    }
+
+    static func hoverRingBorder(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color.accentColor.opacity(0.48)
+            : neutralHoverBorder(for: colorScheme)
+    }
+
+    static func hoverRingGlow(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark
+            ? Color.accentColor.opacity(0.12)
+            : .clear
+    }
 }
 
 struct SettingsSectionDivider: View {

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GroupSettingsView.swift
@@ -132,6 +132,7 @@ struct GroupSettingsView: View {
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     @Environment(\.colorScheme) private var colorScheme
     @State private var pendingSelectedGroupId: UUID?
+    @State private var pendingSelectionRequestID: UUID?
 
     /// A deferred-write binding for columnVisibility.
     ///
@@ -160,6 +161,7 @@ struct GroupSettingsView: View {
             set: { newValue in
                 guard store.selectedGroupId != newValue else {
                     pendingSelectedGroupId = nil
+                    pendingSelectionRequestID = nil
                     return
                 }
 
@@ -171,15 +173,20 @@ struct GroupSettingsView: View {
                     )
                 }
 
+                let requestID = UUID()
                 pendingSelectedGroupId = newValue
+                pendingSelectionRequestID = requestID
 
                 Task { @MainActor in
+                    guard pendingSelectionRequestID == requestID else { return }
+
                     if store.selectedGroupId != newValue {
                         store.selectedGroupId = newValue
                     }
 
-                    if pendingSelectedGroupId == newValue {
+                    if pendingSelectionRequestID == requestID, pendingSelectedGroupId == newValue {
                         pendingSelectedGroupId = nil
+                        pendingSelectionRequestID = nil
                     }
                 }
             }
@@ -222,11 +229,17 @@ struct GroupSettingsView: View {
         }
         .navigationTitle("App Groups".localized(language: selectedLanguage))
         .background(SettingsChromePalette.windowBackground(for: colorScheme))
-        .onChange(of: store.selectedGroupId) { _, _ in
+        .onChange(of: store.selectedGroupId) { _, newValue in
+            if pendingSelectedGroupId == newValue {
+                pendingSelectedGroupId = nil
+                pendingSelectionRequestID = nil
+                return
+            }
+
             // External selection changes (menu commands, URL routing, etc.) should win immediately.
             pendingSelectedGroupId = nil
-        }
-        .onChange(of: store.selectedGroupId) { _, newValue in
+            pendingSelectionRequestID = nil
+
             if let newValue {
                 GroupSwitchPerformanceTracker.shared.beginGroupSwitch(
                     to: newValue,


### PR DESCRIPTION
## What changed

- added clear dark-mode hover and focus treatment for the group name field in Settings
- made group selection updates feel faster by using immediate local selection state, avoiding full detail-pane rebuilds, and narrowing animations to drag-preview updates only
- moved app icons to placeholder-first async loading and deferred lower-priority settings content so the top of the pane paints sooner
- cached running-app quick-add data and kept debug-only group-switch instrumentation to measure follow-up tuning in real navigation flows

## Why this changed

Closes #46 and addresses the follow-up UX issue discovered during testing: after fixing the dark-mode field feedback, switching between groups still felt noticeably slow, especially with `Command+Up/Down` navigation.

## Performance evidence

Initial instrumentation showed a completed keyboard-driven switch at about `603.89 ms`, with the old `editor visible` milestone not landing until `576.83 ms`.

After the staged rendering work, a measured keyboard-driven switch reached:

- `header visible` at `151.62 ms`
- `apps section visible` at `228.82 ms`
- `quick-add ready` at `248.19 ms`
- total completion at `248.23 ms`

The branch keeps the debug-only `GroupSwitchPerformanceTracker` so we can continue validating warm and large-group navigation behavior over time.

## Validation

- passed: `swift test`
- passed: `xcodebuild -project ShortcutCycle/ShortcutCycle.xcodeproj -scheme ShortcutCycle -configuration Debug -destination 'generic/platform=macOS' build`
