### PR TITLE
Update unreleased 1.6 release notes

### DIFF
--- a/ShortcutCycle/AppStoreMetadata.md
+++ b/ShortcutCycle/AppStoreMetadata.md
@@ -15,7 +15,8 @@ Stop endlessly tabbing. Group your apps by context—Web, Code, Social—and cyc
 ## What's New (1.6)
 - Add currently running apps to a group with one click from the group editor.
 - Get suggested shortcut ideas for groups that do not have a hotkey yet.
-- Enjoy clearer first-run setup and more reliable switching when apps are minimized or Settings is open on another Space.
+- Use new Settings keyboard shortcuts to jump between groups, reorder them, and toggle appearance faster.
+- Enjoy clearer first-run setup and more reliable switching when quick-tapping, holding to reveal the HUD, restoring minimized apps, or working with Settings on another Space.
 
 ## App Icon
 `ShortcutCycle/ShortcutCycle/Assets.xcassets/AppIcon.appiconset/1024.png`

--- a/ShortcutCycle/AppStoreMetadata.md
+++ b/ShortcutCycle/AppStoreMetadata.md
@@ -16,7 +16,7 @@ Stop endlessly tabbing. Group your apps by context—Web, Code, Social—and cyc
 - Add currently running apps to a group with one click from the group editor.
 - Get suggested shortcut ideas for groups that do not have a hotkey yet.
 - Use new Settings keyboard shortcuts to jump between groups, reorder them, and toggle appearance faster.
-- Enjoy clearer first-run setup and more reliable switching when quick-tapping, holding to reveal the HUD, restoring minimized apps, or working with Settings on another Space.
+- Enjoy clearer first-run setup and more reliable switching when quick-tapping, holding to reveal the HUD, using multi-profile apps, or working with Settings on another Space.
 
 ## App Icon
 `ShortcutCycle/ShortcutCycle/Assets.xcassets/AppIcon.appiconset/1024.png`

--- a/ShortcutCycle/CHANGELOG.md
+++ b/ShortcutCycle/CHANGELOG.md
@@ -2,19 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.6] - 2026-04-05
+## [1.6] - Unreleased
 
 ### Added
 - **Running app quick add**: The group editor now lets you add currently running apps with a single click, reducing the need to browse Finder when capturing an active workflow.
 - **Shortcut suggestions**: Groups without an assigned shortcut now surface suggested hotkeys to streamline initial setup.
+- **Expanded Settings shortcuts**: ShortcutCycle now adds more macOS-style commands while Settings is open, including Settings, appearance toggle, group navigation, and group reordering shortcuts.
 
 ### Changed
 - **First-launch onboarding**: On first manual launch, ShortcutCycle now opens Settings with a welcome banner to make the menu bar-based app model clearer.
+- **Language sync**: Changing the app language now updates bundled controls more consistently, including shortcut recorders and imported settings.
+- **Backup comparison guidance**: The Automatic Backup Browser now defaults comparisons to the next older backup and explains how to pick a different baseline.
 
 ### Fixed
 - **Narrow group editor layout**: Cycling Mode controls now remain readable and properly aligned in narrow group editor layouts.
 - **Desktop Space jumps**: App switching no longer sends users to another Space merely because the Settings window is open elsewhere.
 - **Minimized multi-profile windows**: Minimized multi-profile app instances (for example, multiple Firefox profiles) are now excluded from the HUD when macOS cannot reliably restore a specific minimized instance without Accessibility permission. Instances hidden with Cmd+H remain visible because `unhide()+activate()` restores them reliably. When all instances of a multi-profile app are minimized, ShortcutCycle preserves one HUD entry so the app remains accessible.
+- **Quick-tap and press-and-hold reliability**: Blind switching, HUD reveal timing, and modifier-release finalization now follow the same session flow so rapid taps and peek-to-reveal interactions stay in sync.
 
 ## [1.5] - 2026-03-01
 

--- a/ShortcutCycle/CHANGELOG.md
+++ b/ShortcutCycle/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - **First-launch onboarding**: On first manual launch, ShortcutCycle now opens Settings with a welcome banner to make the menu bar-based app model clearer.
 - **Language sync**: Changing the app language now updates bundled controls more consistently, including shortcut recorders and imported settings.
-- **Backup comparison guidance**: The Automatic Backup Browser now defaults comparisons to the next older backup and explains how to pick a different baseline.
+- **Backup comparison guidance**: The Automatic Backup Browser now explains that comparisons default to the next older backup and points to the "Changes from" picker for choosing a different baseline.
 
 ### Fixed
 - **Narrow group editor layout**: Cycling Mode controls now remain readable and properly aligned in narrow group editor layouts.


### PR DESCRIPTION
## Summary
- mark the 1.6 changelog entry as unreleased instead of dated April 5, 2026
- expand the 1.6 changelog to cover the full user-facing release scope
- refresh the App Store What's New copy for the final 1.6 candidate

## Testing
- not run (docs-only change)