### PR TITLE
Fix menu bar popover missing groups on some machines (#52)

### DIFF
--- a/ShortcutCycle/ShortcutCycle/Views/MenuBarView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/MenuBarView.swift
@@ -30,6 +30,44 @@ struct MenuBarView: View {
         #endif
     }
 
+    // MARK: - Group list sizing
+
+    /// Approximate rendered height of a single `MenuBarGroupRow`
+    /// (body-font HStack with `.padding(.vertical, 6)` → ~29pt).
+    /// Update this if the row's padding or typography changes.
+    private static let groupRowHeight: CGFloat = 29
+
+    /// Maximum number of group rows visible without scrolling.
+    /// Beyond this the ScrollView scrolls; the popover never grows further.
+    private static let maxVisibleGroupRows = 10
+
+    /// Height of the "No groups created yet" placeholder.
+    private static let emptyGroupListHeight: CGFloat = 60
+
+    /// Upper bound on the group-list frame — hard cap that always applies,
+    /// regardless of whether the measured height arrived yet.
+    private static var groupListMaxHeight: CGFloat {
+        CGFloat(maxVisibleGroupRows) * groupRowHeight
+    }
+
+    /// First-paint height estimate for the group list.
+    ///
+    /// `MenuBarExtra` sizes its host window from the initial layout pass,
+    /// which runs before `GeometryReader` can report the measured content
+    /// height via `HeightPreferenceKey`. Falling back to `nil` there was
+    /// non-deterministic across machines and sometimes produced a 0-height
+    /// ScrollView that clipped all groups. Seeding the frame with a
+    /// group-count-derived estimate gives the first pass a concrete size;
+    /// the preference-driven update below then refines it to the exact
+    /// measured value.
+    private var estimatedListHeight: CGFloat {
+        let count = store.groups.count
+        let estimated = count == 0
+            ? Self.emptyGroupListHeight
+            : CGFloat(count) * Self.groupRowHeight
+        return min(estimated, Self.groupListMaxHeight)
+    }
+
     private var launchAtLoginBinding: Binding<Bool> {
         #if DEBUG
         if let screenshotLaunchAtLogin {
@@ -84,7 +122,7 @@ struct MenuBarView: View {
                     }
                 )
             }
-            .frame(height: listHeight > 0 ? min(listHeight, 800) : nil)
+            .frame(height: listHeight > 0 ? min(listHeight, Self.groupListMaxHeight) : estimatedListHeight)
             .onPreferenceChange(HeightPreferenceKey.self) { height in
                 listHeight = height
             }


### PR DESCRIPTION
## Summary

- Fixes #52 — on some machines the menu bar popover opened without any groups visible.
- Root cause: commit 1419f1a used `nil` as the first-paint fallback for the ScrollView frame height. SwiftUI resolved that unconstrained frame as ~0 on certain macOS layout states, `MenuBarExtra` locked the window to that size before `GeometryReader`/`onPreferenceChange` could refine it, and the list was clipped.
- Fix: seed the frame with a group-count-derived estimate (`count × 29pt`) so the first layout pass is always concrete. The existing preference-key feedback still refines to the exact measured height on the next frame.
- Also caps the list at **10 visible rows** (`10 × 29 = 290pt`) so the popover never grows past 10 groups regardless of screen size; beyond that the ScrollView engages.
- Tuning knobs are single-line constants at the top of `MenuBarView`: `groupRowHeight`, `maxVisibleGroupRows`, `emptyGroupListHeight`.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 511 tests, 0 failures
- [x] Manual: on the machine where #52 reproduced, open the menu bar popover and confirm groups render on first open
- [x] Manual: with <10 groups, popover fits tightly with no trailing gap
- [x] Manual: with >10 groups, popover caps at 10 rows and scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)