### PR TITLE
[codex] Fix stuck HUD after shortcut release

### DIFF
--- a/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
@@ -466,11 +466,10 @@ class HUDManager: @preconcurrency ObservableObject {
         }
 
         addFlagsMonitor(false)
-        if sessionPhase != .revealed {
-            // During the invisible preparation phase we watch both scopes. Once the
-            // HUD is revealed we re-install local-only monitoring.
-            addFlagsMonitor(true)
-        }
+        // ShortcutCycle runs as an accessory app and presents the HUD in a
+        // non-activating panel. Keep a global fallback even after reveal because
+        // local key delivery is not reliable once focus shifts away from the app.
+        addFlagsMonitor(true)
 
         if sessionPhase == .revealed {
             // Give a tiny grace period for state to settle or for fast release.
@@ -515,8 +514,7 @@ class HUDManager: @preconcurrency ObservableObject {
                 }
             }
 
-            if sessionPhase != .revealed,
-               let keyMonitor = addGlobalEventMonitor(.keyUp, handleKeyUp) {
+            if let keyMonitor = addGlobalEventMonitor(.keyUp, handleKeyUp) {
                 keyUpMonitors.append(keyMonitor)
             }
 

--- a/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/HUD/HUDManager.swift
@@ -738,6 +738,10 @@ class HUDManager: @preconcurrency ObservableObject {
     }
 
     private func finalizeSwitchAndHide() {
+        guard sessionPhase != .idle else {
+            return
+        }
+
         // Modifiers released
         revealTimer?.invalidate()
         revealTimer = nil
@@ -888,6 +892,26 @@ class HUDManager: @preconcurrency ObservableObject {
     
     /// Hide the HUD
     func hide() {
+        guard sessionPhase != .idle
+            || window != nil
+            || currentSelectedAppId != nil
+            || currentShortcut != nil
+            || pendingActiveAppId != nil
+            || hideTimer != nil
+            || revealTimer != nil
+            || loopTimer != nil
+            || currentLoopKey != nil
+            || isLoopKeyHeld
+            || isRepeatingLoopActive
+            || lastRequestTime != nil
+            || lastLocalKeyDownTime != nil
+            || !eventMonitors.isEmpty
+            || !keyUpMonitors.isEmpty
+            || appResignObserver != nil
+        else {
+            return
+        }
+
         fireOnFinalizeIfNeeded()
         let hadRevealedHUD = isHUDRevealedThisSession()
         window?.orderOut(nil)

--- a/ShortcutCycle/ShortcutCycleTests/PressAndHoldTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/PressAndHoldTests.swift
@@ -309,6 +309,46 @@ final class PressAndHoldTests: XCTestCase {
     }
 
     @MainActor
+    func testDelayedShowReinstallsGlobalReleaseFallbackAfterReveal() async {
+        manager.currentModifierFlags = { [.command, .shift] }
+
+        manager.scheduleShow(
+            items: [HUDAppItem(bundleId: "com.test.1", name: "Test 1", icon: nil)],
+            activeAppId: "com.test.current",
+            modifierFlags: [.command, .shift],
+            shortcut: "Cmd+Shift+J",
+            activeKey: .j
+        )
+
+        XCTAssertEqual(
+            globalMonitorMasks.filter { $0 == .flagsChanged }.count,
+            1,
+            "Prepared HUD should register one global flagsChanged fallback before reveal"
+        )
+        XCTAssertEqual(
+            globalMonitorMasks.filter { $0 == .keyUp }.count,
+            1,
+            "Prepared HUD should register one global keyUp fallback before reveal"
+        )
+
+        timerMock.fireLastNonRepeatingTimer()
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertTrue(manager.isVisible, "Reveal timer should transition the HUD into the visible state")
+        XCTAssertEqual(
+            globalMonitorMasks.filter { $0 == .flagsChanged }.count,
+            2,
+            "Revealed HUD should reinstall a global flagsChanged fallback in addition to the local monitor"
+        )
+        XCTAssertEqual(
+            globalMonitorMasks.filter { $0 == .keyUp }.count,
+            2,
+            "Revealed HUD should reinstall a global keyUp fallback in addition to the local monitor"
+        )
+    }
+
+    @MainActor
     func testDelayedShowClosesOffSpaceSettingsWindowBeforeHUDActivation() async {
         let settingsWindow = MockWindow(
             identifier: NSUserInterfaceItemIdentifier("settings"),

--- a/ShortcutCycle/ShortcutCycleTests/PressAndHoldTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/PressAndHoldTests.swift
@@ -309,8 +309,12 @@ final class PressAndHoldTests: XCTestCase {
     }
 
     @MainActor
-    func testDelayedShowReinstallsGlobalReleaseFallbackAfterReveal() async {
+    func testDelayedShowReinstallsGlobalReleaseFallbackAfterReveal() async throws {
         manager.currentModifierFlags = { [.command, .shift] }
+        var activateCount = 0
+        manager.activatePendingTargetApp = { _ in
+            activateCount += 1
+        }
 
         manager.scheduleShow(
             items: [HUDAppItem(bundleId: "com.test.1", name: "Test 1", icon: nil)],
@@ -346,6 +350,15 @@ final class PressAndHoldTests: XCTestCase {
             2,
             "Revealed HUD should reinstall a global keyUp fallback in addition to the local monitor"
         )
+
+        let flagsHandler = try XCTUnwrap(latestGlobalMonitorHandler(for: .flagsChanged))
+        flagsHandler(try makeFlagsChangedEvent(modifierFlags: []))
+        await Task.yield()
+        await Task.yield()
+
+        XCTAssertFalse(manager.isSessionActive, "The revealed global release fallback should end the HUD session")
+        XCTAssertFalse(manager.isVisible, "The revealed global release fallback should hide the HUD on modifier release")
+        XCTAssertEqual(activateCount, 1, "The pending target should activate exactly once when the global release fallback fires")
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- keep global `flagsChanged` and `keyUp` release fallbacks active after the HUD is revealed
- add a regression test covering the revealed `Cmd+Shift+letter` path

## Root Cause
ShortcutCycle runs as an accessory app and shows the HUD in a non-activating panel. After reveal, the HUD was switching to local-only release monitoring. For shortcuts like `Cmd+Shift+J` and `Cmd+Shift+A`, local release delivery can be missed, which leaves the HUD visible until some later click changes state.

## Impact
This keeps the revealed HUD dismissible when the shortcut is released, instead of depending on a later click to recover.

## Validation
- `swift test --filter PressAndHoldTests`