### PR TITLE
[codex] Add optional Settings shortcut with conflict warnings

### DIFF
--- a/ShortcutCycle/CHANGELOG.md
+++ b/ShortcutCycle/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - **Running app quick add**: The group editor now lets you add currently running apps with a single click, reducing the need to browse Finder when capturing an active workflow.
 - **Shortcut suggestions**: Groups without an assigned shortcut now surface suggested hotkeys to streamline initial setup.
 - **Expanded Settings shortcuts**: ShortcutCycle now adds more macOS-style commands while Settings is open, including Settings, appearance toggle, group navigation, and group reordering shortcuts.
+- **Optional Settings window shortcut**: Users can assign their own global shortcut in General settings to show, focus, or hide the Settings window. No shortcut is assigned by default.
 
 ### Changed
 - **First-launch onboarding**: On first manual launch, ShortcutCycle now opens Settings with a welcome banner to make the menu bar-based app model clearer.

--- a/ShortcutCycle/CHANGELOG.md
+++ b/ShortcutCycle/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - **Shortcut conflicts**: Duplicate group and Settings window shortcut assignments now show a warning and clear the newly recorded shortcut instead of allowing both actions to share the same hotkey.
+- **Shortcut recorder localization**: Shortcut recorder placeholder text and app-command conflict warnings now follow ShortcutCycle's in-app language setting.
 - **Narrow group editor layout**: Cycling Mode controls now remain readable and properly aligned in narrow group editor layouts.
 - **Desktop Space jumps**: App switching no longer sends users to another Space merely because the Settings window is open elsewhere.
 - **Minimized multi-profile windows**: Minimized multi-profile app instances (for example, multiple Firefox profiles) are now excluded from the HUD when macOS cannot reliably restore a specific minimized instance without Accessibility permission. Instances hidden with Cmd+H remain visible because `unhide()+activate()` restores them reliably. When all instances of a multi-profile app are minimized, ShortcutCycle preserves one HUD entry so the app remains accessible.

--- a/ShortcutCycle/CHANGELOG.md
+++ b/ShortcutCycle/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - **Backup comparison guidance**: The Automatic Backup Browser now explains that comparisons default to the next older backup and points to the "Changes from" picker for choosing a different baseline.
 
 ### Fixed
+- **Shortcut conflicts**: Duplicate group and Settings window shortcut assignments now show a warning and clear the newly recorded shortcut instead of allowing both actions to share the same hotkey.
 - **Narrow group editor layout**: Cycling Mode controls now remain readable and properly aligned in narrow group editor layouts.
 - **Desktop Space jumps**: App switching no longer sends users to another Space merely because the Settings window is open elsewhere.
 - **Minimized multi-profile windows**: Minimized multi-profile app instances (for example, multiple Firefox profiles) are now excluded from the HUD when macOS cannot reliably restore a specific minimized instance without Accessibility permission. Instances hidden with Cmd+H remain visible because `unhide()+activate()` restores them reliably. When all instances of a multi-profile app are minimized, ShortcutCycle preserves one HUD entry so the app remains accessible.

--- a/ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj
+++ b/ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		017 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 901 /* KeyboardShortcuts */; };
 		A1B200022F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */; };
 		A1B200032F70000100C0DE01 /* ShortcutSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */; };
+		A1B200052F70000200C0DE01 /* LocalizedKeyboardShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B200042F70000200C0DE01 /* LocalizedKeyboardShortcutRecorder.swift */; };
+		A1B200062F70000200C0DE01 /* LocalizedKeyboardShortcutRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B200042F70000200C0DE01 /* LocalizedKeyboardShortcutRecorder.swift */; };
 		C0A1D0012FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1D0002FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift */; };
 		C0A1D0022FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1D0002FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift */; };
 		DF88A3762F300B110042E749 /* HUDManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88A3542F300B110042E749 /* HUDManager.swift */; };
@@ -113,6 +115,7 @@
 /* Begin PBXFileReference section */
 		100 /* ShortcutCycle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShortcutCycle.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B200012F70000100C0DE01 /* ShortcutSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutSuggestion.swift; sourceTree = "<group>"; };
+		A1B200042F70000200C0DE01 /* LocalizedKeyboardShortcutRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizedKeyboardShortcutRecorder.swift; sourceTree = "<group>"; };
 		C0A1D0002FB0000100C0DE01 /* GroupSwitchPerformanceTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupSwitchPerformanceTracker.swift; sourceTree = "<group>"; };
 		DF88A3372F300B110042E749 /* String+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Localization.swift"; sourceTree = "<group>"; };
 		DF88A3392F300B110042E749 /* AppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppGroup.swift; sourceTree = "<group>"; };
@@ -408,6 +411,7 @@
 				DF88A36C2F300B110042E749 /* AppDropZoneView.swift */,
 				DF88A36D2F300B110042E749 /* GroupEditView.swift */,
 				DF88A36E2F300B110042E749 /* GroupListView.swift */,
+				A1B200042F70000200C0DE01 /* LocalizedKeyboardShortcutRecorder.swift */,
 				DF88A36F2F300B110042E749 /* MainView.swift */,
 				DF88A3702F300B110042E749 /* MenuBarView.swift */,
 				F1A200012FB1000100C0DE01 /* ScreenshotAccentSwitch.swift */,
@@ -592,6 +596,7 @@
 				DF88A3922F300C640042E749 /* GroupSettingsView.swift in Sources */,
 				DF88A3932F300C640042E749 /* GeneralSettingsView.swift in Sources */,
 				DF88A3942F300C6A0042E749 /* GroupEditView.swift in Sources */,
+				A1B200052F70000200C0DE01 /* LocalizedKeyboardShortcutRecorder.swift in Sources */,
 				DF88A3952F300C6A0042E749 /* MainView.swift in Sources */,
 				DF88A3962F300C6A0042E749 /* MenuBarView.swift in Sources */,
 				DF88A3972F300C6A0042E749 /* AppDropZoneView.swift in Sources */,
@@ -635,6 +640,7 @@
 				DF88A3B32F300CB10042E749 /* BackupBrowserView.swift in Sources */,
 				DF88A37E2F300B110042E749 /* HUDPreviewView.swift in Sources */,
 				DF88A37F2F300B110042E749 /* GroupSettingsView.swift in Sources */,
+				A1B200062F70000200C0DE01 /* LocalizedKeyboardShortcutRecorder.swift in Sources */,
 				DF88A3802F300B110042E749 /* AppSwitcherHUDView.swift in Sources */,
 				DF88A3812F300B110042E749 /* MainView.swift in Sources */,
 				DF88A3822F300B110042E749 /* AppSwitcher.swift in Sources */,

--- a/ShortcutCycle/ShortcutCycle/Models/ShortcutSuggestion.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/ShortcutSuggestion.swift
@@ -23,14 +23,102 @@ public enum ShortcutSuggestions {
             .init(.nine, modifiers: [.option])
         ]
 
-        let takenShortcuts = groups.compactMap { group -> KeyboardShortcuts.Shortcut? in
+        var takenShortcuts = groups.compactMap { group -> KeyboardShortcuts.Shortcut? in
             guard group.id != groupID else { return nil }
             return KeyboardShortcuts.getShortcut(for: group.shortcutName)
+        }
+        if let settingsShortcut = KeyboardShortcuts.getShortcut(for: .toggleSettings) {
+            takenShortcuts.append(settingsShortcut)
         }
 
         return candidates
             .filter { candidate in !takenShortcuts.contains(candidate) }
             .prefix(limit)
             .map { $0 }
+    }
+}
+
+enum ShortcutAssignmentOwner: Equatable {
+    case settingsWindow
+    case group(id: UUID, name: String)
+
+    static func == (lhs: ShortcutAssignmentOwner, rhs: ShortcutAssignmentOwner) -> Bool {
+        switch (lhs, rhs) {
+        case (.settingsWindow, .settingsWindow):
+            return true
+        case let (.group(lhsID, _), .group(rhsID, _)):
+            return lhsID == rhsID
+        default:
+            return false
+        }
+    }
+
+    var identifier: String {
+        switch self {
+        case .settingsWindow:
+            return "settingsWindow"
+        case let .group(id, _):
+            return "group-\(id.uuidString)"
+        }
+    }
+
+    func displayName(language: String) -> String {
+        switch self {
+        case .settingsWindow:
+            return "Settings Window".localized(language: language)
+        case let .group(_, name):
+            let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmedName.isEmpty ? "Group Name".localized(language: language) : trimmedName
+        }
+    }
+}
+
+struct ShortcutAssignmentConflict: Equatable, Identifiable {
+    let shortcut: KeyboardShortcuts.Shortcut
+    let owner: ShortcutAssignmentOwner
+
+    var id: String {
+        "\(shortcut.carbonKeyCode)-\(shortcut.carbonModifiers)-\(owner.identifier)"
+    }
+
+    @MainActor
+    func message(language: String) -> String {
+        let conflictMessage = String(
+            format: "The shortcut %@ is already used by %@.".localized(language: language),
+            shortcut.description,
+            owner.displayName(language: language)
+        )
+        let guidance = "Choose a different shortcut to avoid triggering both actions.".localized(language: language)
+        return "\(conflictMessage)\n\n\(guidance)"
+    }
+}
+
+enum ShortcutAssignmentConflicts {
+    @MainActor
+    static func conflict(
+        for shortcut: KeyboardShortcuts.Shortcut?,
+        assigning owner: ShortcutAssignmentOwner,
+        groups: [AppGroup]
+    ) -> ShortcutAssignmentConflict? {
+        guard let shortcut else {
+            return nil
+        }
+
+        if owner != .settingsWindow,
+           KeyboardShortcuts.getShortcut(for: .toggleSettings) == shortcut {
+            return ShortcutAssignmentConflict(shortcut: shortcut, owner: .settingsWindow)
+        }
+
+        for group in groups where owner != .group(id: group.id, name: group.name) {
+            guard KeyboardShortcuts.getShortcut(for: group.shortcutName) == shortcut else {
+                continue
+            }
+            return ShortcutAssignmentConflict(
+                shortcut: shortcut,
+                owner: .group(id: group.id, name: group.name)
+            )
+        }
+
+        return nil
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Models/ShortcutSuggestion.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/ShortcutSuggestion.swift
@@ -41,6 +41,7 @@ public enum ShortcutSuggestions {
 enum ShortcutAssignmentOwner: Equatable {
     case settingsWindow
     case group(id: UUID, name: String)
+    case appCommand(titleKey: String)
 
     static func == (lhs: ShortcutAssignmentOwner, rhs: ShortcutAssignmentOwner) -> Bool {
         switch (lhs, rhs) {
@@ -48,6 +49,8 @@ enum ShortcutAssignmentOwner: Equatable {
             return true
         case let (.group(lhsID, _), .group(rhsID, _)):
             return lhsID == rhsID
+        case let (.appCommand(lhsTitle), .appCommand(rhsTitle)):
+            return lhsTitle == rhsTitle
         default:
             return false
         }
@@ -59,6 +62,8 @@ enum ShortcutAssignmentOwner: Equatable {
             return "settingsWindow"
         case let .group(id, _):
             return "group-\(id.uuidString)"
+        case let .appCommand(titleKey):
+            return "appCommand-\(titleKey)"
         }
     }
 
@@ -69,6 +74,8 @@ enum ShortcutAssignmentOwner: Equatable {
         case let .group(_, name):
             let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmedName.isEmpty ? "Group Name".localized(language: language) : trimmedName
+        case let .appCommand(titleKey):
+            return titleKey.localized(language: language)
         }
     }
 }
@@ -104,6 +111,10 @@ enum ShortcutAssignmentConflicts {
             return nil
         }
 
+        if let conflict = AppCommandShortcutConflicts.conflict(for: shortcut) {
+            return conflict
+        }
+
         if owner != .settingsWindow,
            KeyboardShortcuts.getShortcut(for: .toggleSettings) == shortcut {
             return ShortcutAssignmentConflict(shortcut: shortcut, owner: .settingsWindow)
@@ -120,5 +131,41 @@ enum ShortcutAssignmentConflicts {
         }
 
         return nil
+    }
+}
+
+enum AppCommandShortcutConflicts {
+    private struct AppCommandShortcut {
+        let titleKey: String
+        let shortcut: KeyboardShortcuts.Shortcut
+    }
+
+    private static let shortcuts: [AppCommandShortcut] = [
+        .init(titleKey: "Settings...", shortcut: .init(.comma, modifiers: [.command])),
+        .init(titleKey: "Add Group", shortcut: .init(.n, modifiers: [.command])),
+        .init(titleKey: "Delete Group", shortcut: .init(.delete, modifiers: [.command])),
+        .init(titleKey: "Toggle Sidebar", shortcut: .init(.s, modifiers: [.command, .control])),
+        .init(titleKey: "Toggle Appearance", shortcut: .init(.a, modifiers: [.command, .control])),
+        .init(titleKey: "Groups", shortcut: .init(.one, modifiers: [.command])),
+        .init(titleKey: "General", shortcut: .init(.two, modifiers: [.command])),
+        .init(titleKey: "Previous Group", shortcut: .init(.upArrow, modifiers: [.command])),
+        .init(titleKey: "Next Group", shortcut: .init(.downArrow, modifiers: [.command])),
+        .init(titleKey: "Previous Group", shortcut: .init(.leftBracket, modifiers: [.command])),
+        .init(titleKey: "Next Group", shortcut: .init(.rightBracket, modifiers: [.command])),
+        .init(titleKey: "Previous Group", shortcut: .init(.k, modifiers: [.command])),
+        .init(titleKey: "Next Group", shortcut: .init(.j, modifiers: [.command])),
+        .init(titleKey: "Move Group Up", shortcut: .init(.upArrow, modifiers: [.command, .option])),
+        .init(titleKey: "Move Group Down", shortcut: .init(.downArrow, modifiers: [.command, .option]))
+    ]
+
+    static func conflict(for shortcut: KeyboardShortcuts.Shortcut) -> ShortcutAssignmentConflict? {
+        guard let command = shortcuts.first(where: { $0.shortcut == shortcut }) else {
+            return nil
+        }
+
+        return ShortcutAssignmentConflict(
+            shortcut: shortcut,
+            owner: .appCommand(titleKey: command.titleKey)
+        )
     }
 }

--- a/ShortcutCycle/ShortcutCycle/Models/ShortcutSuggestion.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/ShortcutSuggestion.swift
@@ -38,12 +38,12 @@ public enum ShortcutSuggestions {
     }
 }
 
-enum ShortcutAssignmentOwner: Equatable {
+public enum ShortcutAssignmentOwner: Equatable {
     case settingsWindow
     case group(id: UUID, name: String)
     case appCommand(titleKey: String)
 
-    static func == (lhs: ShortcutAssignmentOwner, rhs: ShortcutAssignmentOwner) -> Bool {
+    public static func == (lhs: ShortcutAssignmentOwner, rhs: ShortcutAssignmentOwner) -> Bool {
         switch (lhs, rhs) {
         case (.settingsWindow, .settingsWindow):
             return true
@@ -56,7 +56,7 @@ enum ShortcutAssignmentOwner: Equatable {
         }
     }
 
-    var identifier: String {
+    fileprivate var identifier: String {
         switch self {
         case .settingsWindow:
             return "settingsWindow"
@@ -67,42 +67,42 @@ enum ShortcutAssignmentOwner: Equatable {
         }
     }
 
-    func displayName(language: String) -> String {
+    public func displayName(localize: (String) -> String) -> String {
         switch self {
         case .settingsWindow:
-            return "Settings Window".localized(language: language)
+            return localize("Settings Window")
         case let .group(_, name):
             let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmedName.isEmpty ? "Group Name".localized(language: language) : trimmedName
+            return trimmedName.isEmpty ? localize("Group Name") : trimmedName
         case let .appCommand(titleKey):
-            return titleKey.localized(language: language)
+            return localize(titleKey)
         }
     }
 }
 
-struct ShortcutAssignmentConflict: Equatable, Identifiable {
-    let shortcut: KeyboardShortcuts.Shortcut
-    let owner: ShortcutAssignmentOwner
+public struct ShortcutAssignmentConflict: Equatable, Identifiable {
+    public let shortcut: KeyboardShortcuts.Shortcut
+    public let owner: ShortcutAssignmentOwner
 
-    var id: String {
+    public var id: String {
         "\(shortcut.carbonKeyCode)-\(shortcut.carbonModifiers)-\(owner.identifier)"
     }
 
     @MainActor
-    func message(language: String) -> String {
+    public func message(localize: (String) -> String) -> String {
         let conflictMessage = String(
-            format: "The shortcut %@ is already used by %@.".localized(language: language),
+            format: localize("The shortcut %@ is already used by %@."),
             shortcut.description,
-            owner.displayName(language: language)
+            owner.displayName(localize: localize)
         )
-        let guidance = "Choose a different shortcut to avoid triggering both actions.".localized(language: language)
+        let guidance = localize("Choose a different shortcut to avoid triggering both actions.")
         return "\(conflictMessage)\n\n\(guidance)"
     }
 }
 
-enum ShortcutAssignmentConflicts {
+public enum ShortcutAssignmentConflicts {
     @MainActor
-    static func conflict(
+    public static func conflict(
         for shortcut: KeyboardShortcuts.Shortcut?,
         assigning owner: ShortcutAssignmentOwner,
         groups: [AppGroup]

--- a/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "نافذة الإعدادات";
 "Shortcuts" = "اختصارات";
+"Shortcut Already Used" = "الاختصار مستخدم بالفعل";
+"The shortcut %@ is already used by %@." = "الاختصار %@ مستخدم بالفعل بواسطة %@.";
+"Choose a different shortcut to avoid triggering both actions." = "اختر اختصارًا مختلفًا لتجنب تشغيل الإجراءين معًا.";
 
 "Add Group" = "إضافة مجموعة";
 "Delete Group" = "حذف المجموعة";

--- a/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ar.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "نافذة الإعدادات";
 "Shortcuts" = "اختصارات";
+"Record Shortcut" = "سجل اختصاراً";
+"Press Shortcut" = "اضغط على الاختصار";
 "Shortcut Already Used" = "الاختصار مستخدم بالفعل";
 "The shortcut %@ is already used by %@." = "الاختصار %@ مستخدم بالفعل بواسطة %@.";
 "Choose a different shortcut to avoid triggering both actions." = "اختر اختصارًا مختلفًا لتجنب تشغيل الإجراءين معًا.";
+"OK" = "حسنًا";
 
 "Add Group" = "إضافة مجموعة";
 "Delete Group" = "حذف المجموعة";

--- a/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "Einstellungsfenster";
 "Shortcuts" = "Kurzbefehle";
+"Record Shortcut" = "Kurzbefehl aufnehmen";
+"Press Shortcut" = "Kurzbefehl wählen…";
 "Shortcut Already Used" = "Tastenkürzel bereits verwendet";
 "The shortcut %@ is already used by %@." = "Das Tastenkürzel %@ wird bereits von %@ verwendet.";
 "Choose a different shortcut to avoid triggering both actions." = "Wählen Sie ein anderes Tastenkürzel, damit nicht beide Aktionen ausgelöst werden.";
+"OK" = "OK";
 "Add Group" = "Gruppe hinzufügen";
 "Delete Group" = "Gruppe löschen";
 "Toggle Sidebar" = "Seitenleiste ein-/ausblenden";

--- a/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/de.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "Einstellungsfenster";
 "Shortcuts" = "Kurzbefehle";
+"Shortcut Already Used" = "Tastenkürzel bereits verwendet";
+"The shortcut %@ is already used by %@." = "Das Tastenkürzel %@ wird bereits von %@ verwendet.";
+"Choose a different shortcut to avoid triggering both actions." = "Wählen Sie ein anderes Tastenkürzel, damit nicht beide Aktionen ausgelöst werden.";
 "Add Group" = "Gruppe hinzufügen";
 "Delete Group" = "Gruppe löschen";
 "Toggle Sidebar" = "Seitenleiste ein-/ausblenden";

--- a/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
@@ -69,6 +69,9 @@
 /* Settings Shortcut */
 "Settings Window" = "Settings Window";
 "Shortcuts" = "Shortcuts";
+"Shortcut Already Used" = "Shortcut Already Used";
+"The shortcut %@ is already used by %@." = "The shortcut %@ is already used by %@.";
+"Choose a different shortcut to avoid triggering both actions." = "Choose a different shortcut to avoid triggering both actions.";
 
 "Add Group" = "Add Group";
 "Delete Group" = "Delete Group";

--- a/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/en.lproj/Localizable.strings
@@ -69,9 +69,12 @@
 /* Settings Shortcut */
 "Settings Window" = "Settings Window";
 "Shortcuts" = "Shortcuts";
+"Record Shortcut" = "Record Shortcut";
+"Press Shortcut" = "Press Shortcut";
 "Shortcut Already Used" = "Shortcut Already Used";
 "The shortcut %@ is already used by %@." = "The shortcut %@ is already used by %@.";
 "Choose a different shortcut to avoid triggering both actions." = "Choose a different shortcut to avoid triggering both actions.";
+"OK" = "OK";
 
 "Add Group" = "Add Group";
 "Delete Group" = "Delete Group";

--- a/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "Ventana de ajustes";
 "Shortcuts" = "Atajos";
+"Shortcut Already Used" = "Atajo ya usado";
+"The shortcut %@ is already used by %@." = "El atajo %@ ya lo usa %@.";
+"Choose a different shortcut to avoid triggering both actions." = "Elige otro atajo para evitar activar ambas acciones.";
 "Add Group" = "Añadir grupo";
 "Delete Group" = "Eliminar grupo";
 "Toggle Sidebar" = "Alternar barra lateral";

--- a/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/es.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "Ventana de ajustes";
 "Shortcuts" = "Atajos";
+"Record Shortcut" = "Grabar atajo";
+"Press Shortcut" = "Pulsar atajo";
 "Shortcut Already Used" = "Atajo ya usado";
 "The shortcut %@ is already used by %@." = "El atajo %@ ya lo usa %@.";
 "Choose a different shortcut to avoid triggering both actions." = "Elige otro atajo para evitar activar ambas acciones.";
+"OK" = "Aceptar";
 "Add Group" = "Añadir grupo";
 "Delete Group" = "Eliminar grupo";
 "Toggle Sidebar" = "Alternar barra lateral";

--- a/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "Fenêtre des paramètres";
 "Shortcuts" = "Raccourcis";
+"Record Shortcut" = "Enregistrer le raccourci";
+"Press Shortcut" = "Saisir un raccourci";
 "Shortcut Already Used" = "Raccourci déjà utilisé";
 "The shortcut %@ is already used by %@." = "Le raccourci %@ est déjà utilisé par %@.";
 "Choose a different shortcut to avoid triggering both actions." = "Choisissez un autre raccourci pour éviter de déclencher les deux actions.";
+"OK" = "OK";
 "Add Group" = "Ajouter un groupe";
 "Delete Group" = "Supprimer le groupe";
 "Toggle Sidebar" = "Afficher/masquer la barre latérale";

--- a/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/fr.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "Fenêtre des paramètres";
 "Shortcuts" = "Raccourcis";
+"Shortcut Already Used" = "Raccourci déjà utilisé";
+"The shortcut %@ is already used by %@." = "Le raccourci %@ est déjà utilisé par %@.";
+"Choose a different shortcut to avoid triggering both actions." = "Choisissez un autre raccourci pour éviter de déclencher les deux actions.";
 "Add Group" = "Ajouter un groupe";
 "Delete Group" = "Supprimer le groupe";
 "Toggle Sidebar" = "Afficher/masquer la barre latérale";

--- a/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "Finestra impostazioni";
 "Shortcuts" = "Comandi rapidi";
+"Shortcut Already Used" = "Scorciatoia già in uso";
+"The shortcut %@ is already used by %@." = "La scorciatoia %@ è già usata da %@.";
+"Choose a different shortcut to avoid triggering both actions." = "Scegli una scorciatoia diversa per evitare di attivare entrambe le azioni.";
 "Add Group" = "Aggiungi gruppo";
 "Delete Group" = "Elimina gruppo";
 "Toggle Sidebar" = "Mostra/nascondi barra laterale";

--- a/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/it.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "Finestra impostazioni";
 "Shortcuts" = "Comandi rapidi";
+"Record Shortcut" = "Registra scorciatoia";
+"Press Shortcut" = "Premi scorciatoia";
 "Shortcut Already Used" = "Scorciatoia già in uso";
 "The shortcut %@ is already used by %@." = "La scorciatoia %@ è già usata da %@.";
 "Choose a different shortcut to avoid triggering both actions." = "Scegli una scorciatoia diversa per evitare di attivare entrambe le azioni.";
+"OK" = "OK";
 "Add Group" = "Aggiungi gruppo";
 "Delete Group" = "Elimina gruppo";
 "Toggle Sidebar" = "Mostra/nascondi barra laterale";

--- a/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "設定ウィンドウ";
 "Shortcuts" = "ショートカット";
+"Shortcut Already Used" = "ショートカットは使用済みです";
+"The shortcut %@ is already used by %@." = "ショートカット %@ はすでに %@ で使用されています。";
+"Choose a different shortcut to avoid triggering both actions." = "両方のアクションが実行されないように、別のショートカットを選択してください。";
 "Add Group" = "グループを追加";
 "Delete Group" = "グループを削除";
 "Toggle Sidebar" = "サイドバーを切り替え";

--- a/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ja.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "設定ウィンドウ";
 "Shortcuts" = "ショートカット";
+"Record Shortcut" = "キーを記録";
+"Press Shortcut" = "キーを押してください";
 "Shortcut Already Used" = "ショートカットは使用済みです";
 "The shortcut %@ is already used by %@." = "ショートカット %@ はすでに %@ で使用されています。";
 "Choose a different shortcut to avoid triggering both actions." = "両方のアクションが実行されないように、別のショートカットを選択してください。";
+"OK" = "OK";
 "Add Group" = "グループを追加";
 "Delete Group" = "グループを削除";
 "Toggle Sidebar" = "サイドバーを切り替え";

--- a/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "설정 창";
 "Shortcuts" = "단축키";
+"Shortcut Already Used" = "이미 사용 중인 단축키";
+"The shortcut %@ is already used by %@." = "단축키 %@은(는) 이미 %@에서 사용 중입니다.";
+"Choose a different shortcut to avoid triggering both actions." = "두 동작이 모두 실행되지 않도록 다른 단축키를 선택하세요.";
 "Add Group" = "그룹 추가";
 "Delete Group" = "그룹 삭제";
 "Toggle Sidebar" = "사이드바 전환";

--- a/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ko.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "설정 창";
 "Shortcuts" = "단축키";
+"Record Shortcut" = "단축키 등록";
+"Press Shortcut" = "단축키 입력";
 "Shortcut Already Used" = "이미 사용 중인 단축키";
 "The shortcut %@ is already used by %@." = "단축키 %@은(는) 이미 %@에서 사용 중입니다.";
 "Choose a different shortcut to avoid triggering both actions." = "두 동작이 모두 실행되지 않도록 다른 단축키를 선택하세요.";
+"OK" = "확인";
 "Add Group" = "그룹 추가";
 "Delete Group" = "그룹 삭제";
 "Toggle Sidebar" = "사이드바 전환";

--- a/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "Instellingenvenster";
 "Shortcuts" = "Sneltoetsen";
+"Record Shortcut" = "Toetscombinatie opnemen";
+"Press Shortcut" = "Voer toetscombinatie in";
 "Shortcut Already Used" = "Sneltoets al in gebruik";
 "The shortcut %@ is already used by %@." = "De sneltoets %@ wordt al gebruikt door %@.";
 "Choose a different shortcut to avoid triggering both actions." = "Kies een andere sneltoets om te voorkomen dat beide acties worden geactiveerd.";
+"OK" = "OK";
 "Add Group" = "Groep toevoegen";
 "Delete Group" = "Groep verwijderen";
 "Toggle Sidebar" = "Zijbalk tonen/verbergen";

--- a/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/nl.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "Instellingenvenster";
 "Shortcuts" = "Sneltoetsen";
+"Shortcut Already Used" = "Sneltoets al in gebruik";
+"The shortcut %@ is already used by %@." = "De sneltoets %@ wordt al gebruikt door %@.";
+"Choose a different shortcut to avoid triggering both actions." = "Kies een andere sneltoets om te voorkomen dat beide acties worden geactiveerd.";
 "Add Group" = "Groep toevoegen";
 "Delete Group" = "Groep verwijderen";
 "Toggle Sidebar" = "Zijbalk tonen/verbergen";

--- a/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "Okno ustawień";
 "Shortcuts" = "Skróty";
+"Shortcut Already Used" = "Skrót jest już używany";
+"The shortcut %@ is already used by %@." = "Skrót %@ jest już używany przez %@.";
+"Choose a different shortcut to avoid triggering both actions." = "Wybierz inny skrót, aby uniknąć uruchamiania obu działań.";
 "Add Group" = "Dodaj grupę";
 "Delete Group" = "Usuń grupę";
 "Toggle Sidebar" = "Przełącz pasek boczny";

--- a/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pl.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "Okno ustawień";
 "Shortcuts" = "Skróty";
+"Record Shortcut" = "Nagraj skrót";
+"Press Shortcut" = "Naciśnij skrót";
 "Shortcut Already Used" = "Skrót jest już używany";
 "The shortcut %@ is already used by %@." = "Skrót %@ jest już używany przez %@.";
 "Choose a different shortcut to avoid triggering both actions." = "Wybierz inny skrót, aby uniknąć uruchamiania obu działań.";
+"OK" = "OK";
 "Add Group" = "Dodaj grupę";
 "Delete Group" = "Usuń grupę";
 "Toggle Sidebar" = "Przełącz pasek boczny";

--- a/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "Janela de Configurações";
 "Shortcuts" = "Atalhos";
+"Record Shortcut" = "Gravar Atalho";
+"Press Shortcut" = "Digite o Atalho";
 "Shortcut Already Used" = "Atalho já usado";
 "The shortcut %@ is already used by %@." = "O atalho %@ já é usado por %@.";
 "Choose a different shortcut to avoid triggering both actions." = "Escolha outro atalho para evitar acionar as duas ações.";
+"OK" = "OK";
 "Add Group" = "Adicionar grupo";
 "Delete Group" = "Excluir grupo";
 "Toggle Sidebar" = "Alternar barra lateral";

--- a/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/pt-BR.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "Janela de Configurações";
 "Shortcuts" = "Atalhos";
+"Shortcut Already Used" = "Atalho já usado";
+"The shortcut %@ is already used by %@." = "O atalho %@ já é usado por %@.";
+"Choose a different shortcut to avoid triggering both actions." = "Escolha outro atalho para evitar acionar as duas ações.";
 "Add Group" = "Adicionar grupo";
 "Delete Group" = "Excluir grupo";
 "Toggle Sidebar" = "Alternar barra lateral";

--- a/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "Окно настроек";
 "Shortcuts" = "Горячие клавиши";
+"Record Shortcut" = "Добавить";
+"Press Shortcut" = "Запись…";
 "Shortcut Already Used" = "Сочетание уже используется";
 "The shortcut %@ is already used by %@." = "Сочетание %@ уже используется: %@.";
 "Choose a different shortcut to avoid triggering both actions." = "Выберите другое сочетание, чтобы не запускать оба действия.";
+"OK" = "OK";
 "Add Group" = "Добавить группу";
 "Delete Group" = "Удалить группу";
 "Toggle Sidebar" = "Переключить боковую панель";

--- a/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/ru.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "Окно настроек";
 "Shortcuts" = "Горячие клавиши";
+"Shortcut Already Used" = "Сочетание уже используется";
+"The shortcut %@ is already used by %@." = "Сочетание %@ уже используется: %@.";
+"Choose a different shortcut to avoid triggering both actions." = "Выберите другое сочетание, чтобы не запускать оба действия.";
 "Add Group" = "Добавить группу";
 "Delete Group" = "Удалить группу";
 "Toggle Sidebar" = "Переключить боковую панель";

--- a/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "Ayarlar Penceresi";
 "Shortcuts" = "Kısayollar";
+"Record Shortcut" = "Kısayol Kaydet";
+"Press Shortcut" = "Kısayola Bas";
 "Shortcut Already Used" = "Kısayol zaten kullanılıyor";
 "The shortcut %@ is already used by %@." = "%@ kısayolu zaten %@ tarafından kullanılıyor.";
 "Choose a different shortcut to avoid triggering both actions." = "İki eylemin birden tetiklenmesini önlemek için farklı bir kısayol seçin.";
+"OK" = "Tamam";
 "Add Group" = "Grup Ekle";
 "Delete Group" = "Grubu Sil";
 "Toggle Sidebar" = "Kenar Çubuğunu Aç/Kapat";

--- a/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/tr.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "Ayarlar Penceresi";
 "Shortcuts" = "Kısayollar";
+"Shortcut Already Used" = "Kısayol zaten kullanılıyor";
+"The shortcut %@ is already used by %@." = "%@ kısayolu zaten %@ tarafından kullanılıyor.";
+"Choose a different shortcut to avoid triggering both actions." = "İki eylemin birden tetiklenmesini önlemek için farklı bir kısayol seçin.";
 "Add Group" = "Grup Ekle";
 "Delete Group" = "Grubu Sil";
 "Toggle Sidebar" = "Kenar Çubuğunu Aç/Kapat";

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "设置窗口";
 "Shortcuts" = "快捷键";
+"Shortcut Already Used" = "快捷键已被使用";
+"The shortcut %@ is already used by %@." = "快捷键 %@ 已被 %@ 使用。";
+"Choose a different shortcut to avoid triggering both actions." = "请选择其他快捷键，避免同时触发两个操作。";
 
 "Add Group" = "添加群组";
 "Delete Group" = "删除群组";

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hans.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "设置窗口";
 "Shortcuts" = "快捷键";
+"Record Shortcut" = "设置快捷键";
+"Press Shortcut" = "按下快捷键";
 "Shortcut Already Used" = "快捷键已被使用";
 "The shortcut %@ is already used by %@." = "快捷键 %@ 已被 %@ 使用。";
 "Choose a different shortcut to avoid triggering both actions." = "请选择其他快捷键，避免同时触发两个操作。";
+"OK" = "好";
 
 "Add Group" = "添加群组";
 "Delete Group" = "删除群组";

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
@@ -70,6 +70,9 @@
 /* Settings Shortcut */
 "Settings Window" = "設定視窗";
 "Shortcuts" = "快速鍵";
+"Shortcut Already Used" = "快速鍵已被使用";
+"The shortcut %@ is already used by %@." = "快速鍵 %@ 已被 %@ 使用。";
+"Choose a different shortcut to avoid triggering both actions." = "請選擇其他快速鍵，避免同時觸發兩個操作。";
 
 "Add Group" = "新增群組";
 "Delete Group" = "刪除群組";

--- a/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
+++ b/ShortcutCycle/ShortcutCycle/Resources/zh-Hant.lproj/Localizable.strings
@@ -70,9 +70,12 @@
 /* Settings Shortcut */
 "Settings Window" = "設定視窗";
 "Shortcuts" = "快速鍵";
+"Record Shortcut" = "設定快速鍵";
+"Press Shortcut" = "按下快速鍵";
 "Shortcut Already Used" = "快速鍵已被使用";
 "The shortcut %@ is already used by %@." = "快速鍵 %@ 已被 %@ 使用。";
 "Choose a different shortcut to avoid triggering both actions." = "請選擇其他快速鍵，避免同時觸發兩個操作。";
+"OK" = "好";
 
 "Add Group" = "新增群組";
 "Delete Group" = "刪除群組";

--- a/ShortcutCycle/ShortcutCycle/Services/SettingsWindowLifecycleCoordinator.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/SettingsWindowLifecycleCoordinator.swift
@@ -1,6 +1,12 @@
 import Foundation
 import AppKit
 
+enum SettingsWindowToggleAction: Equatable {
+    case open
+    case focus
+    case dismiss
+}
+
 enum SettingsWindowLifecycleCoordinator {
     static func isSettingsWindow(_ window: NSWindow) -> Bool {
         window.identifier?.rawValue == "settings"
@@ -30,6 +36,25 @@ enum SettingsWindowLifecycleCoordinator {
         }
 
         return .regular
+    }
+
+    static func toggleAction(for window: NSWindow?) -> SettingsWindowToggleAction {
+        guard let window, isSettingsWindow(window), window.isVisible else {
+            return .open
+        }
+
+        if isDismissibleSettingsWindow(window) {
+            return .dismiss
+        }
+
+        return .focus
+    }
+
+    static func isDismissibleSettingsWindow(_ window: NSWindow) -> Bool {
+        isSettingsWindow(window)
+            && window.isVisible
+            && window.isKeyWindow
+            && !hasVisibleAttachedSheet(window)
     }
 
     private static func hasVisibleAttachedSheet(_ window: NSWindow) -> Bool {

--- a/ShortcutCycle/ShortcutCycle/Services/ShortcutManager.swift
+++ b/ShortcutCycle/ShortcutCycle/Services/ShortcutManager.swift
@@ -34,7 +34,6 @@ class ShortcutManager: @preconcurrency ObservableObject {
     
     /// Register all shortcuts from the group store
     func registerAllShortcuts() {
-#if DEBUG
         // Register the settings toggle shortcut once.
         // KeyboardShortcuts.onKeyDown appends handlers and does not replace existing ones.
         if !hasRegisteredToggleSettingsShortcut {
@@ -45,7 +44,6 @@ class ShortcutManager: @preconcurrency ObservableObject {
             }
             hasRegisteredToggleSettingsShortcut = true
         }
-#endif
         
         // Unregister all previously registered shortcuts first
         // This is crucial to handle deleted groups or disabled groups
@@ -125,21 +123,14 @@ class ShortcutManager: @preconcurrency ObservableObject {
     
     /// Handle the settings toggle shortcut
     private func handleToggleSettings() {
-        // Find if the settings window is already open
         let settingsWindow = NSApp.windows.first { window in
             SettingsWindowLifecycleCoordinator.isSettingsWindow(window)
         }
-        
-        if let window = settingsWindow, window.isVisible {
-            if window.isKeyWindow {
-                // If it's already the key window, close it to toggle off
-                window.close()
-            } else {
-                // If it's open but not key, bring it to front through the shared restore path.
-                ShortcutCycleURLRouter.openSettingsFromOutsideView()
-            }
-        } else {
-            // Window is closed, ordered out, or not in memory.
+
+        switch SettingsWindowLifecycleCoordinator.toggleAction(for: settingsWindow) {
+        case .dismiss:
+            settingsWindow?.close()
+        case .focus, .open:
             ShortcutCycleURLRouter.openSettingsFromOutsideView()
         }
     }

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -583,6 +583,7 @@ private struct GroupShortcutEditor: View {
 
     @AppStorage("selectedLanguage") private var selectedLanguage = "system"
     @State private var shortcutRefreshToken = 0
+    @State private var shortcutConflict: ShortcutAssignmentConflict?
 
     private var shortcutName: KeyboardShortcuts.Name {
         .forGroup(groupId)
@@ -621,7 +622,7 @@ private struct GroupShortcutEditor: View {
             VStack(alignment: .leading, spacing: 8) {
                 KeyboardShortcuts.Recorder(for: shortcutName, onChange: handleShortcutChange)
                     .padding(.leading, 4)
-                    .id("\(selectedLanguage)-\(groupId.uuidString)") // Recreate only when localization or target group changes
+                    .id("\(selectedLanguage)-\(groupId.uuidString)-\(shortcutRefreshToken)")
                     .task(id: groupId) {
                         GroupSwitchPerformanceTracker.shared.markRecorderMounted(for: groupId)
                     }
@@ -672,17 +673,48 @@ private struct GroupShortcutEditor: View {
         .task(id: groupId) {
             GroupSwitchPerformanceTracker.shared.markShortcutSectionVisible(for: groupId)
         }
+        .alert(item: $shortcutConflict) { conflict in
+            Alert(
+                title: Text("Shortcut Already Used".localized(language: selectedLanguage)),
+                message: Text(conflict.message(language: selectedLanguage)),
+                dismissButton: .default(Text("OK"))
+            )
+        }
     }
 
     @MainActor
     private func assignShortcut(_ shortcut: KeyboardShortcuts.Shortcut) {
+        guard !showConflictIfNeeded(for: shortcut) else {
+            return
+        }
+
         KeyboardShortcuts.setShortcut(shortcut, for: shortcutName)
         refreshShortcutState()
     }
 
     @MainActor
     private func handleShortcutChange(_ shortcut: KeyboardShortcuts.Shortcut?) {
+        if let shortcut, showConflictIfNeeded(for: shortcut) {
+            KeyboardShortcuts.setShortcut(nil, for: shortcutName)
+            refreshShortcutState()
+            return
+        }
+
         refreshShortcutState()
+    }
+
+    @MainActor
+    private func showConflictIfNeeded(for shortcut: KeyboardShortcuts.Shortcut) -> Bool {
+        guard let conflict = ShortcutAssignmentConflicts.conflict(
+            for: shortcut,
+            assigning: .group(id: groupId, name: group.name),
+            groups: store.groups
+        ) else {
+            return false
+        }
+
+        shortcutConflict = conflict
+        return true
     }
 
     @MainActor

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -620,7 +620,11 @@ private struct GroupShortcutEditor: View {
                 .font(.headline)
 
             VStack(alignment: .leading, spacing: 8) {
-                KeyboardShortcuts.Recorder(for: shortcutName, onChange: handleShortcutChange)
+                LocalizedKeyboardShortcutRecorder(
+                    name: shortcutName,
+                    selectedLanguage: selectedLanguage,
+                    onChange: handleShortcutChange
+                )
                     .padding(.leading, 4)
                     .id("\(selectedLanguage)-\(groupId.uuidString)-\(shortcutRefreshToken)")
                     .task(id: groupId) {
@@ -677,7 +681,7 @@ private struct GroupShortcutEditor: View {
             Alert(
                 title: Text("Shortcut Already Used".localized(language: selectedLanguage)),
                 message: Text(conflict.message(language: selectedLanguage)),
-                dismissButton: .default(Text("OK"))
+                dismissButton: .default(Text("OK".localized(language: selectedLanguage)))
             )
         }
     }

--- a/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/GroupEditView.swift
@@ -680,7 +680,7 @@ private struct GroupShortcutEditor: View {
         .alert(item: $shortcutConflict) { conflict in
             Alert(
                 title: Text("Shortcut Already Used".localized(language: selectedLanguage)),
-                message: Text(conflict.message(language: selectedLanguage)),
+                message: Text(conflict.message { $0.localized(language: selectedLanguage) }),
                 dismissButton: .default(Text("OK".localized(language: selectedLanguage)))
             )
         }

--- a/ShortcutCycle/ShortcutCycle/Views/LocalizedKeyboardShortcutRecorder.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/LocalizedKeyboardShortcutRecorder.swift
@@ -1,0 +1,154 @@
+import AppKit
+import KeyboardShortcuts
+import SwiftUI
+
+struct LocalizedKeyboardShortcutRecorder: NSViewRepresentable {
+    typealias NSViewType = KeyboardShortcuts.RecorderCocoa
+
+    let name: KeyboardShortcuts.Name
+    let selectedLanguage: String
+    let onChange: ((KeyboardShortcuts.Shortcut?) -> Void)?
+
+    init(
+        name: KeyboardShortcuts.Name,
+        selectedLanguage: String,
+        onChange: ((KeyboardShortcuts.Shortcut?) -> Void)? = nil
+    ) {
+        self.name = name
+        self.selectedLanguage = selectedLanguage
+        self.onChange = onChange
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selectedLanguage: selectedLanguage)
+    }
+
+    func makeNSView(context: Context) -> NSViewType {
+        let recorder = NSViewType(for: name, onChange: onChange)
+        context.coordinator.attach(recorder)
+        context.coordinator.update(selectedLanguage: selectedLanguage)
+        return recorder
+    }
+
+    func updateNSView(_ nsView: NSViewType, context: Context) {
+        nsView.shortcutName = name
+        context.coordinator.update(selectedLanguage: selectedLanguage)
+    }
+
+    final class Coordinator {
+        private weak var recorder: NSViewType?
+        private var selectedLanguage: String
+        private var isRecording = false
+        private var recorderActiveObserver: NSObjectProtocol?
+
+        init(selectedLanguage: String) {
+            self.selectedLanguage = selectedLanguage
+        }
+
+        deinit {
+            if let recorderActiveObserver {
+                NotificationCenter.default.removeObserver(recorderActiveObserver)
+            }
+            MenuShortcutRecorderGuard.shared.end()
+        }
+
+        func attach(_ recorder: NSViewType) {
+            self.recorder = recorder
+            startObservingIfNeeded()
+            applyPlaceholder()
+        }
+
+        func update(selectedLanguage: String) {
+            self.selectedLanguage = selectedLanguage
+            applyPlaceholder()
+        }
+
+        private func startObservingIfNeeded() {
+            guard recorderActiveObserver == nil else {
+                return
+            }
+
+            recorderActiveObserver = NotificationCenter.default.addObserver(
+                forName: Notification.Name("KeyboardShortcuts_recorderActiveStatusDidChange"),
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                guard let self else { return }
+                let isActive = notification.userInfo?["isActive"] as? Bool ?? false
+                handleRecorderActiveStatusDidChange(isActive: isActive)
+            }
+        }
+
+        private func handleRecorderActiveStatusDidChange(isActive: Bool) {
+            if isActive {
+                MenuShortcutRecorderGuard.shared.begin()
+                isRecording = recorder?.currentEditor() != nil
+            } else {
+                isRecording = false
+                MenuShortcutRecorderGuard.shared.end()
+            }
+
+            applyPlaceholder()
+        }
+
+        private func applyPlaceholder() {
+            let key = isRecording ? "Press Shortcut" : "Record Shortcut"
+            recorder?.placeholderString = key.localized(language: selectedLanguage)
+        }
+    }
+}
+
+private final class MenuShortcutRecorderGuard {
+    static let shared = MenuShortcutRecorderGuard()
+
+    private struct SavedMenuShortcut {
+        let item: NSMenuItem
+        let keyEquivalent: String
+        let modifierMask: NSEvent.ModifierFlags
+    }
+
+    private var savedShortcuts: [SavedMenuShortcut] = []
+
+    private init() {}
+
+    func begin() {
+        guard savedShortcuts.isEmpty else {
+            return
+        }
+
+        let menuItems = allMenuItems(in: NSApp.mainMenu)
+        for item in menuItems where !item.keyEquivalent.isEmpty {
+            savedShortcuts.append(
+                SavedMenuShortcut(
+                    item: item,
+                    keyEquivalent: item.keyEquivalent,
+                    modifierMask: item.keyEquivalentModifierMask
+                )
+            )
+            item.keyEquivalent = ""
+            item.keyEquivalentModifierMask = []
+        }
+    }
+
+    func end() {
+        guard !savedShortcuts.isEmpty else {
+            return
+        }
+
+        for savedShortcut in savedShortcuts {
+            savedShortcut.item.keyEquivalent = savedShortcut.keyEquivalent
+            savedShortcut.item.keyEquivalentModifierMask = savedShortcut.modifierMask
+        }
+        savedShortcuts.removeAll()
+    }
+
+    private func allMenuItems(in menu: NSMenu?) -> [NSMenuItem] {
+        guard let menu else {
+            return []
+        }
+
+        return menu.items.flatMap { item in
+            [item] + allMenuItems(in: item.submenu)
+        }
+    }
+}

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import KeyboardShortcuts
 import UniformTypeIdentifiers
 #if canImport(ShortcutCycleCore)
 import ShortcutCycleCore
@@ -233,6 +234,16 @@ struct GeneralSettingsView: View {
                     }
                 }
                 .pickerStyle(.menu)
+
+                KeyboardShortcuts.Recorder(
+                    "Settings Window".localized(language: selectedLanguage),
+                    name: .toggleSettings
+                ) { _ in
+                    Task { @MainActor in
+                        ShortcutManager.shared.registerAllShortcuts()
+                    }
+                }
+                .id("settings-window-shortcut-\(selectedLanguage)")
 
                 Button {
                     showShortcutReferencePopover = true

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
@@ -30,6 +30,8 @@ struct GeneralSettingsView: View {
     @State private var showBackupBrowser = false
     @State private var manualBackupFeedback: String?
     @State private var showShortcutReferencePopover = false
+    @State private var settingsShortcutRefreshToken = 0
+    @State private var shortcutConflict: ShortcutAssignmentConflict?
 
     // Clipboard state
     @State private var showClipboardImportConfirmation = false
@@ -106,6 +108,13 @@ struct GeneralSettingsView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text("Your settings have been imported from clipboard.".localized(language: selectedLanguage))
+        }
+        .alert(item: $shortcutConflict) { conflict in
+            Alert(
+                title: Text("Shortcut Already Used".localized(language: selectedLanguage)),
+                message: Text(conflict.message(language: selectedLanguage)),
+                dismissButton: .default(Text("OK"))
+            )
         }
     }
 
@@ -238,12 +247,12 @@ struct GeneralSettingsView: View {
                 KeyboardShortcuts.Recorder(
                     "Settings Window".localized(language: selectedLanguage),
                     name: .toggleSettings
-                ) { _ in
+                ) { shortcut in
                     Task { @MainActor in
-                        ShortcutManager.shared.registerAllShortcuts()
+                        handleSettingsWindowShortcutChange(shortcut)
                     }
                 }
-                .id("settings-window-shortcut-\(selectedLanguage)")
+                .id("settings-window-shortcut-\(selectedLanguage)-\(settingsShortcutRefreshToken)")
 
                 Button {
                     showShortcutReferencePopover = true
@@ -348,6 +357,26 @@ struct GeneralSettingsView: View {
         }
     }
     #endif
+
+    @MainActor
+    private func handleSettingsWindowShortcutChange(_ shortcut: KeyboardShortcuts.Shortcut?) {
+        if let conflict = ShortcutAssignmentConflicts.conflict(
+            for: shortcut,
+            assigning: .settingsWindow,
+            groups: store.groups
+        ) {
+            KeyboardShortcuts.setShortcut(nil, for: .toggleSettings)
+            shortcutConflict = conflict
+        }
+
+        refreshSettingsShortcutState()
+    }
+
+    @MainActor
+    private func refreshSettingsShortcutState() {
+        settingsShortcutRefreshToken += 1
+        ShortcutManager.shared.registerAllShortcuts()
+    }
 
     // MARK: - Export/Import Actions
     

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
@@ -113,7 +113,7 @@ struct GeneralSettingsView: View {
             Alert(
                 title: Text("Shortcut Already Used".localized(language: selectedLanguage)),
                 message: Text(conflict.message(language: selectedLanguage)),
-                dismissButton: .default(Text("OK"))
+                dismissButton: .default(Text("OK".localized(language: selectedLanguage)))
             )
         }
     }
@@ -244,13 +244,17 @@ struct GeneralSettingsView: View {
                 }
                 .pickerStyle(.menu)
 
-                KeyboardShortcuts.Recorder(
-                    "Settings Window".localized(language: selectedLanguage),
-                    name: .toggleSettings
-                ) { shortcut in
-                    Task { @MainActor in
-                        handleSettingsWindowShortcutChange(shortcut)
+                LabeledContent {
+                    LocalizedKeyboardShortcutRecorder(
+                        name: .toggleSettings,
+                        selectedLanguage: selectedLanguage
+                    ) { shortcut in
+                        Task { @MainActor in
+                            handleSettingsWindowShortcutChange(shortcut)
+                        }
                     }
+                } label: {
+                    Text("Settings Window".localized(language: selectedLanguage))
                 }
                 .id("settings-window-shortcut-\(selectedLanguage)-\(settingsShortcutRefreshToken)")
 

--- a/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
+++ b/ShortcutCycle/ShortcutCycle/Views/Settings/GeneralSettingsView.swift
@@ -112,7 +112,7 @@ struct GeneralSettingsView: View {
         .alert(item: $shortcutConflict) { conflict in
             Alert(
                 title: Text("Shortcut Already Used".localized(language: selectedLanguage)),
-                message: Text(conflict.message(language: selectedLanguage)),
+                message: Text(conflict.message { $0.localized(language: selectedLanguage) }),
                 dismissButton: .default(Text("OK".localized(language: selectedLanguage)))
             )
         }

--- a/ShortcutCycle/ShortcutCycleTests/SettingsWindowLifecycleCoordinatorTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/SettingsWindowLifecycleCoordinatorTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import KeyboardShortcuts
 import XCTest
 @testable import ShortcutCycle
 
@@ -144,5 +145,67 @@ final class SettingsWindowLifecycleCoordinatorTests: XCTestCase {
         XCTAssertEqual(SettingsWindowLifecycleCoordinator.activationPolicy(for: backgroundWindow), .accessory)
         XCTAssertEqual(SettingsWindowLifecycleCoordinator.activationPolicy(for: nonSettingsWindow), .accessory)
         XCTAssertEqual(SettingsWindowLifecycleCoordinator.activationPolicy(for: nil), .accessory)
+    }
+
+    func testToggleActionOpensWhenSettingsWindowIsMissingOrHidden() {
+        let hiddenWindow = MockWindow(
+            identifier: NSUserInterfaceItemIdentifier("settings"),
+            isVisible: false,
+            isOnActiveSpace: true,
+            isKeyWindow: true
+        )
+        let nonSettingsWindow = MockWindow(
+            identifier: NSUserInterfaceItemIdentifier("other"),
+            isVisible: true,
+            isOnActiveSpace: true,
+            isKeyWindow: true
+        )
+
+        XCTAssertEqual(SettingsWindowLifecycleCoordinator.toggleAction(for: nil), .open)
+        XCTAssertEqual(SettingsWindowLifecycleCoordinator.toggleAction(for: hiddenWindow), .open)
+        XCTAssertEqual(SettingsWindowLifecycleCoordinator.toggleAction(for: nonSettingsWindow), .open)
+    }
+
+    func testToggleActionFocusesVisibleBackgroundSettingsWindow() {
+        let window = MockWindow(
+            identifier: NSUserInterfaceItemIdentifier("settings"),
+            isVisible: true,
+            isOnActiveSpace: true
+        )
+
+        XCTAssertEqual(SettingsWindowLifecycleCoordinator.toggleAction(for: window), .focus)
+    }
+
+    func testToggleActionDismissesVisibleKeySettingsWindow() {
+        let window = MockWindow(
+            identifier: NSUserInterfaceItemIdentifier("settings"),
+            isVisible: true,
+            isOnActiveSpace: true,
+            isKeyWindow: true
+        )
+
+        XCTAssertEqual(SettingsWindowLifecycleCoordinator.toggleAction(for: window), .dismiss)
+    }
+
+    func testToggleActionFocusesSettingsWindowWhenVisibleSheetIsAttached() {
+        let sheet = MockWindow(
+            identifier: nil,
+            isVisible: true,
+            isOnActiveSpace: true
+        )
+        let window = MockWindow(
+            identifier: NSUserInterfaceItemIdentifier("settings"),
+            isVisible: true,
+            isOnActiveSpace: true,
+            isKeyWindow: true,
+            attachedSheet: sheet
+        )
+
+        XCTAssertEqual(SettingsWindowLifecycleCoordinator.toggleAction(for: window), .focus)
+        XCTAssertFalse(SettingsWindowLifecycleCoordinator.isDismissibleSettingsWindow(window))
+    }
+
+    func testToggleSettingsShortcutHasNoDefaultShortcut() {
+        XCTAssertNil(KeyboardShortcuts.Name.toggleSettings.defaultShortcut)
     }
 }

--- a/ShortcutCycle/ShortcutCycleTests/ShortcutSuggestionTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/ShortcutSuggestionTests.swift
@@ -187,7 +187,7 @@ final class ShortcutSuggestionTests: XCTestCase {
 
         XCTAssertEqual(conflict?.shortcut, shortcut)
         XCTAssertEqual(conflict?.owner, .appCommand(titleKey: "Next Group"))
-        XCTAssertEqual(conflict?.owner.displayName(language: "zh-Hans"), "下一个群组")
+        XCTAssertEqual(conflict?.owner.displayName { $0 == "Next Group" ? "下一个群组" : $0 }, "下一个群组")
     }
 
     @MainActor

--- a/ShortcutCycle/ShortcutCycleTests/ShortcutSuggestionTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/ShortcutSuggestionTests.swift
@@ -10,6 +10,7 @@ final class ShortcutSuggestionTests: XCTestCase {
 
     @MainActor
     func testAvailableReturnsDeterministicFirstThreeUnusedOptionNumberShortcuts() {
+        let previousSettingsShortcut = KeyboardShortcuts.getShortcut(for: .toggleSettings)
         let excludedGroup = AppGroup(id: UUID(), name: "Excluded")
         let assignedGroups = [
             AppGroup(id: UUID(), name: "First"),
@@ -17,12 +18,14 @@ final class ShortcutSuggestionTests: XCTestCase {
             AppGroup(id: UUID(), name: "Third")
         ]
 
+        KeyboardShortcuts.setShortcut(nil, for: .toggleSettings)
         KeyboardShortcuts.setShortcut(.init(.one, modifiers: [.option]), for: excludedGroup.shortcutName)
         KeyboardShortcuts.setShortcut(.init(.two, modifiers: [.option]), for: assignedGroups[0].shortcutName)
         KeyboardShortcuts.setShortcut(.init(.three, modifiers: [.option]), for: assignedGroups[1].shortcutName)
         KeyboardShortcuts.setShortcut(.init(.four, modifiers: [.option]), for: assignedGroups[2].shortcutName)
 
         defer {
+            KeyboardShortcuts.setShortcut(previousSettingsShortcut, for: .toggleSettings)
             KeyboardShortcuts.setShortcut(nil, for: excludedGroup.shortcutName)
             assignedGroups.forEach { group in
                 KeyboardShortcuts.setShortcut(nil, for: group.shortcutName)
@@ -44,16 +47,19 @@ final class ShortcutSuggestionTests: XCTestCase {
 
     @MainActor
     func testAvailableReturnsFewerThanLimitWhenNotEnoughCandidatesRemain() {
+        let previousSettingsShortcut = KeyboardShortcuts.getShortcut(for: .toggleSettings)
         let optionKeys: [KeyboardShortcuts.Key] = [.one, .two, .three, .four, .five, .six, .seven, .eight, .nine]
         let groups = (1...9).map { index in
             AppGroup(id: UUID(), name: "Group \(index)")
         }
 
+        KeyboardShortcuts.setShortcut(nil, for: .toggleSettings)
         for (index, group) in groups.enumerated() {
             KeyboardShortcuts.setShortcut(.init(optionKeys[index], modifiers: [.option]), for: group.shortcutName)
         }
 
         defer {
+            KeyboardShortcuts.setShortcut(previousSettingsShortcut, for: .toggleSettings)
             groups.forEach { group in
                 KeyboardShortcuts.setShortcut(nil, for: group.shortcutName)
             }
@@ -68,5 +74,118 @@ final class ShortcutSuggestionTests: XCTestCase {
         )
 
         XCTAssertEqual(suggestions, expected)
+    }
+
+    @MainActor
+    func testAvailableExcludesSettingsWindowShortcut() {
+        let previousSettingsShortcut = KeyboardShortcuts.getShortcut(for: .toggleSettings)
+        let group = AppGroup(id: UUID(), name: "Target")
+        KeyboardShortcuts.setShortcut(.init(.one, modifiers: [.option]), for: .toggleSettings)
+
+        defer {
+            KeyboardShortcuts.setShortcut(previousSettingsShortcut, for: .toggleSettings)
+            KeyboardShortcuts.setShortcut(nil, for: group.shortcutName)
+        }
+
+        let expected: [KeyboardShortcuts.Shortcut] = [
+            .init(.two, modifiers: [.option]),
+            .init(.three, modifiers: [.option]),
+            .init(.four, modifiers: [.option])
+        ]
+        let suggestions = ShortcutSuggestions.available(for: [group], excluding: group.id)
+
+        XCTAssertEqual(suggestions, expected)
+    }
+
+    @MainActor
+    func testConflictDetectsSettingsWindowShortcutWhenAssigningGroupShortcut() {
+        let previousSettingsShortcut = KeyboardShortcuts.getShortcut(for: .toggleSettings)
+        let group = AppGroup(id: UUID(), name: "Work")
+        let shortcut = KeyboardShortcuts.Shortcut(.one, modifiers: [.option])
+        KeyboardShortcuts.setShortcut(shortcut, for: .toggleSettings)
+
+        defer {
+            KeyboardShortcuts.setShortcut(previousSettingsShortcut, for: .toggleSettings)
+            KeyboardShortcuts.setShortcut(nil, for: group.shortcutName)
+        }
+
+        let conflict = ShortcutAssignmentConflicts.conflict(
+            for: shortcut,
+            assigning: .group(id: group.id, name: group.name),
+            groups: [group]
+        )
+
+        XCTAssertEqual(conflict?.shortcut, shortcut)
+        XCTAssertEqual(conflict?.owner, .settingsWindow)
+    }
+
+    @MainActor
+    func testConflictDetectsGroupShortcutWhenAssigningSettingsWindowShortcut() {
+        let previousSettingsShortcut = KeyboardShortcuts.getShortcut(for: .toggleSettings)
+        let group = AppGroup(id: UUID(), name: "Work")
+        let shortcut = KeyboardShortcuts.Shortcut(.one, modifiers: [.option])
+        KeyboardShortcuts.setShortcut(nil, for: .toggleSettings)
+        KeyboardShortcuts.setShortcut(shortcut, for: group.shortcutName)
+
+        defer {
+            KeyboardShortcuts.setShortcut(previousSettingsShortcut, for: .toggleSettings)
+            KeyboardShortcuts.setShortcut(nil, for: group.shortcutName)
+        }
+
+        let conflict = ShortcutAssignmentConflicts.conflict(
+            for: shortcut,
+            assigning: .settingsWindow,
+            groups: [group]
+        )
+
+        XCTAssertEqual(conflict?.shortcut, shortcut)
+        XCTAssertEqual(conflict?.owner, .group(id: group.id, name: group.name))
+    }
+
+    @MainActor
+    func testConflictDetectsOtherGroupShortcutWhenAssigningGroupShortcut() {
+        let previousSettingsShortcut = KeyboardShortcuts.getShortcut(for: .toggleSettings)
+        let targetGroup = AppGroup(id: UUID(), name: "Target")
+        let existingGroup = AppGroup(id: UUID(), name: "Existing")
+        let shortcut = KeyboardShortcuts.Shortcut(.one, modifiers: [.option])
+        KeyboardShortcuts.setShortcut(nil, for: .toggleSettings)
+        KeyboardShortcuts.setShortcut(shortcut, for: existingGroup.shortcutName)
+
+        defer {
+            KeyboardShortcuts.setShortcut(previousSettingsShortcut, for: .toggleSettings)
+            KeyboardShortcuts.setShortcut(nil, for: targetGroup.shortcutName)
+            KeyboardShortcuts.setShortcut(nil, for: existingGroup.shortcutName)
+        }
+
+        let conflict = ShortcutAssignmentConflicts.conflict(
+            for: shortcut,
+            assigning: .group(id: targetGroup.id, name: targetGroup.name),
+            groups: [targetGroup, existingGroup]
+        )
+
+        XCTAssertEqual(conflict?.shortcut, shortcut)
+        XCTAssertEqual(conflict?.owner, .group(id: existingGroup.id, name: existingGroup.name))
+    }
+
+    @MainActor
+    func testConflictIgnoresAssignedGroupShortcut() {
+        let previousSettingsShortcut = KeyboardShortcuts.getShortcut(for: .toggleSettings)
+        let group = AppGroup(id: UUID(), name: "Work")
+        let shortcut = KeyboardShortcuts.Shortcut(.one, modifiers: [.option])
+        KeyboardShortcuts.setShortcut(nil, for: .toggleSettings)
+        KeyboardShortcuts.setShortcut(shortcut, for: group.shortcutName)
+
+        defer {
+            KeyboardShortcuts.setShortcut(previousSettingsShortcut, for: .toggleSettings)
+            KeyboardShortcuts.setShortcut(nil, for: group.shortcutName)
+        }
+
+        let conflict = ShortcutAssignmentConflicts.conflict(
+            for: shortcut,
+            assigning: .group(id: group.id, name: group.name),
+            groups: [group]
+        )
+
+        XCTAssertNil(conflict)
     }
 }

--- a/ShortcutCycle/ShortcutCycleTests/ShortcutSuggestionTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/ShortcutSuggestionTests.swift
@@ -168,6 +168,29 @@ final class ShortcutSuggestionTests: XCTestCase {
     }
 
     @MainActor
+    func testConflictDetectsAppCommandShortcutWhenAssigningShortcut() {
+        let previousSettingsShortcut = KeyboardShortcuts.getShortcut(for: .toggleSettings)
+        let group = AppGroup(id: UUID(), name: "Target")
+        let shortcut = KeyboardShortcuts.Shortcut(.downArrow, modifiers: [.command])
+        KeyboardShortcuts.setShortcut(nil, for: .toggleSettings)
+
+        defer {
+            KeyboardShortcuts.setShortcut(previousSettingsShortcut, for: .toggleSettings)
+            KeyboardShortcuts.setShortcut(nil, for: group.shortcutName)
+        }
+
+        let conflict = ShortcutAssignmentConflicts.conflict(
+            for: shortcut,
+            assigning: .group(id: group.id, name: group.name),
+            groups: [group]
+        )
+
+        XCTAssertEqual(conflict?.shortcut, shortcut)
+        XCTAssertEqual(conflict?.owner, .appCommand(titleKey: "Next Group"))
+        XCTAssertEqual(conflict?.owner.displayName(language: "zh-Hans"), "下一个群组")
+    }
+
+    @MainActor
     func testConflictIgnoresAssignedGroupShortcut() {
         let previousSettingsShortcut = KeyboardShortcuts.getShortcut(for: .toggleSettings)
         let group = AppGroup(id: UUID(), name: "Work")


### PR DESCRIPTION
## Summary

Adds an opt-in global shortcut for the Settings window. Users can record their own shortcut in General settings; no shortcut is assigned by default.

## Details

- Enables the existing `toggleSettings` handler in release builds while preserving explicit opt-in behavior.
- Adds a visible `Settings Window` recorder row under General -> Application.
- Centralizes Settings window toggle behavior so the shortcut opens, focuses, or dismisses appropriately.
- Avoids dismissing Settings when a visible attached sheet is open.
- Warns and clears newly recorded duplicate shortcuts when they conflict with another group, the Settings window shortcut, or app menu commands.
- Localizes shortcut recorder placeholder/recording text and conflict alerts so they follow ShortcutCycle's in-app language setting.
- Keeps shortcut conflict detection package-safe for both Xcode and SwiftPM test paths.
- Documents the change in the unreleased changelog.

## Validation

- `swift test --enable-code-coverage`
- `xcodebuild test -project ShortcutCycle/ShortcutCycle.xcodeproj -scheme ShortcutCycle -destination 'platform=macOS' -parallel-testing-enabled NO -only-testing:ShortcutCycleTests/ShortcutSuggestionTests`
- `plutil -lint ShortcutCycle/ShortcutCycle.xcodeproj/project.pbxproj ShortcutCycle/ShortcutCycle/Resources/*.lproj/Localizable.strings`
- `git diff --check`
- User verified the Settings Window option is visible and works.
