### PR TITLE
[codex] Clean up V2EX Tally embed page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_V2EX_TALLY_FORM_URL=https://tally.so/r/FORM_ID

--- a/docs/v2ex/index.html
+++ b/docs/v2ex/index.html
@@ -7,7 +7,6 @@
     <link rel="icon" type="image/png" sizes="32x32" href="../assets/images/favicon-32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="../assets/images/favicon-16.png">
     <link rel="apple-touch-icon" href="../assets/images/app-icon.png">
-    <meta name="NEXT_PUBLIC_V2EX_TALLY_FORM_URL" content="https://tally.so/r/NpPVgO">
 
     <title>ShortcutCycle V2EX 试用申请</title>
     <meta name="description" content="ShortcutCycle V2EX 试用兑换码申请表。邮箱用于发放兑换码和后续一次反馈沟通，V2EX 用户名可选。">
@@ -31,8 +30,6 @@
             --text: #1d1d1f;
             --border: #d2d2d7;
             --nav-height: 58px;
-            --warning-bg: #fff8db;
-            --warning-border: #e8c547;
         }
 
         @media (prefers-color-scheme: dark) {
@@ -40,8 +37,6 @@
                 --bg: #0f0f12;
                 --text: #f5f5f7;
                 --border: #2c2c2e;
-                --warning-bg: #2d2815;
-                --warning-border: #8a6d1d;
             }
         }
 
@@ -97,38 +92,14 @@
         }
 
         .tally-frame {
-            display: none;
+            display: block;
             width: 100%;
             min-height: 1180px;
             border: 0;
             background: var(--bg);
         }
 
-        .tally-frame.visible {
-            display: block;
-        }
-
-        .setup-warning {
-            display: none;
-            width: min(calc(100% - 36px), 720px);
-            margin: 24px auto;
-            padding: 18px 20px;
-            border: 1px solid var(--warning-border);
-            border-radius: 18px;
-            background: var(--warning-bg);
-            color: var(--text);
-            font-size: 0.95rem;
-        }
-
-        .setup-warning.visible {
-            display: block;
-        }
-
         @media (max-width: 520px) {
-            .setup-warning {
-                border-radius: 16px;
-            }
-
             .tally-frame {
                 min-height: 1300px;
             }
@@ -146,46 +117,11 @@
     </header>
 
     <main id="main-content">
-        <p class="setup-warning" id="setup-warning">开发提示：未配置 NEXT_PUBLIC_V2EX_TALLY_FORM_URL。发布 Tally 表单后，把表单 URL 配置到这个变量或页面 meta 标签里。</p>
-        <iframe class="tally-frame" id="tally-frame" title="ShortcutCycle V2EX 试用申请表" loading="lazy"></iframe>
+        <iframe
+            class="tally-frame"
+            src="https://tally.so/embed/NpPVgO"
+            title="ShortcutCycle V2EX 试用申请表"></iframe>
     </main>
-
-    <script>
-        const TALLY_FORM_ENV_NAME = 'NEXT_PUBLIC_V2EX_TALLY_FORM_URL';
-        const formUrlMeta = document.querySelector(`meta[name="${TALLY_FORM_ENV_NAME}"]`);
-        const rawFormUrl = (window[TALLY_FORM_ENV_NAME] || formUrlMeta?.content || '').trim();
-        const setupWarning = document.getElementById('setup-warning');
-        const tallyFrame = document.getElementById('tally-frame');
-
-        function normalizeTallyUrl(value) {
-            try {
-                const url = new URL(value);
-                if (url.hostname !== 'tally.so') return '';
-
-                const match = url.pathname.match(/^\/(?:r|embed)\/([^/?#]+)/);
-                if (!match) return '';
-
-                const embedUrl = new URL(`/embed/${match[1]}`, url.origin);
-                return embedUrl.toString();
-            } catch (error) {
-                return '';
-            }
-        }
-
-        const tallyEmbedUrl = normalizeTallyUrl(rawFormUrl);
-
-        if (tallyEmbedUrl) {
-            tallyFrame.src = tallyEmbedUrl;
-            tallyFrame.classList.add('visible');
-        } else {
-            setupWarning.classList.add('visible');
-            if (rawFormUrl) {
-                console.warn(`${TALLY_FORM_ENV_NAME} must be a Tally share URL like https://tally.so/r/FORM_ID.`);
-            } else {
-                console.warn(`${TALLY_FORM_ENV_NAME} is not configured.`);
-            }
-        }
-    </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

- Simplify `/v2ex/` to embed the published Tally form directly.
- Remove the developer-facing `NEXT_PUBLIC_V2EX_TALLY_FORM_URL` warning/config fallback from the public page.
- Delete the stale one-line `.env.example` that only documented that removed variable.

## Validation

- Verified `input.txt` and `output.txt` were deleted locally.
- Ran `git diff --check`.
- Searched `docs/` for leftover `NEXT_PUBLIC_V2EX`, `setup-warning`, and `开发提示` strings; none remain.
- Previously verified the local `/v2ex/` page renders the Tally form on desktop and mobile, has no wrapper-page console warnings, and keeps the `主页` navigation link working.
