### PR TITLE
Validate localization resources in tests

### DIFF
--- a/ShortcutCycle/ShortcutCycle/Models/SettingsExport.swift
+++ b/ShortcutCycle/ShortcutCycle/Models/SettingsExport.swift
@@ -2,8 +2,9 @@ import Foundation
 import KeyboardShortcuts
 
 enum AppleLanguagePreferenceSync {
-    // Keep in sync with LanguageManager.supportedLanguages.
-    private static let supportedLanguageCodes = [
+    // Keep in sync with LanguageManager.supportedLanguages. LocalizationTests
+    // verifies this list and the app's other localization sources stay aligned.
+    static let supportedLanguageCodes = [
         "en", "de", "fr", "es", "ja", "pt-BR", "zh-Hans", "zh-Hant",
         "it", "ko", "ar", "nl", "pl", "tr", "ru"
     ]

--- a/ShortcutCycle/ShortcutCycleTests/LocalizationTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/LocalizationTests.swift
@@ -89,6 +89,19 @@ final class LocalizationTests: XCTestCase {
 
         return nil
     }
+
+    /// Test that every supported language has a localization resource.
+    func testAllSupportedLocalizationFilesExist() throws {
+        let resourcesDir = try XCTUnwrap(findResourcesDirectory(), "Could not find Resources directory containing localization files")
+
+        for language in supportedLanguages {
+            let langURL = resourcesDir.appendingPathComponent("\(language).lproj/Localizable.strings")
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: langURL.path),
+                "Missing localization file for \(language)"
+            )
+        }
+    }
     
     /// Test that all localization keys in English exist in all other languages
     func testAllLocalizationKeysExistInAllLanguages() throws {
@@ -225,6 +238,10 @@ final class LocalizationTests: XCTestCase {
 
         for language in supportedLanguages {
             let langURL = resourcesDir.appendingPathComponent("\(language).lproj/Localizable.strings")
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: langURL.path),
+                "Missing localization file for \(language)"
+            )
             let langKeys = parseLocalizationKeys(from: langURL)
 
             for key in removedKeys {

--- a/ShortcutCycle/ShortcutCycleTests/LocalizationTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/LocalizationTests.swift
@@ -1,5 +1,7 @@
 import XCTest
+#if canImport(ShortcutCycleCore)
 @testable import ShortcutCycleCore
+#endif
 @testable import ShortcutCycle
 
 /// Tests to ensure all localization keys are present in all supported languages

--- a/ShortcutCycle/ShortcutCycleTests/LocalizationTests.swift
+++ b/ShortcutCycle/ShortcutCycleTests/LocalizationTests.swift
@@ -1,14 +1,14 @@
 import XCTest
+@testable import ShortcutCycleCore
+@testable import ShortcutCycle
 
 /// Tests to ensure all localization keys are present in all supported languages
 final class LocalizationTests: XCTestCase {
     
-    /// All supported language codes in the project
-    private let supportedLanguages = [
-        "en", "de", "es", "fr", "it", "ja", "ko",
-        "nl", "pl", "pt-BR", "ru", "tr", "ar",
-        "zh-Hans", "zh-Hant"
-    ]
+    /// LanguageManager is the application source of truth for supported languages.
+    private var supportedLanguages: [String] {
+        LanguageManager.shared.supportedLanguages.map(\.code)
+    }
     
     /// Parse a Localizable.strings file and return all keys
     private func parseLocalizationKeys(from url: URL) -> Set<String> {
@@ -90,9 +90,26 @@ final class LocalizationTests: XCTestCase {
         return nil
     }
 
-    /// Test that every supported language has a localization resource.
-    func testAllSupportedLocalizationFilesExist() throws {
+    /// Test that localization resources match the application's supported languages.
+    func testLocalizationResourcesMatchSupportedLanguages() throws {
         let resourcesDir = try XCTUnwrap(findResourcesDirectory(), "Could not find Resources directory containing localization files")
+        let expectedLanguages = Set(supportedLanguages)
+        let localizationDirectories = try FileManager.default.contentsOfDirectory(
+            at: resourcesDir,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        let actualLanguages = Set(
+            localizationDirectories
+                .filter { $0.pathExtension == "lproj" }
+                .map { $0.deletingPathExtension().lastPathComponent }
+        )
+
+        XCTAssertEqual(
+            actualLanguages,
+            expectedLanguages,
+            "Localization directories should match LanguageManager.supportedLanguages"
+        )
 
         for language in supportedLanguages {
             let langURL = resourcesDir.appendingPathComponent("\(language).lproj/Localizable.strings")
@@ -101,6 +118,33 @@ final class LocalizationTests: XCTestCase {
                 "Missing localization file for \(language)"
             )
         }
+    }
+
+    func testLanguageSourcesMatchLanguageManager() throws {
+        let expectedLanguages = Set(supportedLanguages)
+        XCTAssertEqual(
+            Set(AppleLanguagePreferenceSync.supportedLanguageCodes),
+            expectedLanguages,
+            "AppleLanguagePreferenceSync should match LanguageManager.supportedLanguages"
+        )
+
+        let resourcesDir = try XCTUnwrap(findResourcesDirectory(), "Could not find Resources directory containing localization files")
+        let infoURL = resourcesDir.deletingLastPathComponent().appendingPathComponent("Info.plist")
+        let infoData = try Data(contentsOf: infoURL)
+        let info = try XCTUnwrap(
+            try PropertyListSerialization.propertyList(from: infoData, options: [], format: nil) as? [String: Any],
+            "Could not parse Info.plist"
+        )
+        let bundleLanguages = try XCTUnwrap(
+            info["CFBundleLocalizations"] as? [String],
+            "Info.plist is missing CFBundleLocalizations"
+        )
+
+        XCTAssertEqual(
+            Set(bundleLanguages),
+            expectedLanguages,
+            "Info.plist CFBundleLocalizations should match LanguageManager.supportedLanguages"
+        )
     }
     
     /// Test that all localization keys in English exist in all other languages


### PR DESCRIPTION
## Summary

- Validate that every supported language has a `Localizable.strings` file.
- Validate that the `.lproj` directory set matches `LanguageManager.supportedLanguages` in both directions.
- Validate that `AppleLanguagePreferenceSync` and `Info.plist` stay aligned with `LanguageManager`.
- Keep the obsolete-key test self-contained by asserting each locale file exists before parsing.

## Why

This addresses [CodeRabbit review comment #3555772479](https://github.com/xcv58/ShortcutCycle/pull/64#discussion_r3555772479) and the follow-up review findings. Missing files previously produced an empty parsed key set, while extra locale directories or drift between the app language list, settings export sync, and bundle metadata could go unnoticed.

`SettingsExport` is part of the Core target and cannot depend on the app target, so the tests use `LanguageManager` as the expected source and fail CI when the other sources are not updated with it.

## Validation

- `swift test --filter LocalizationTests` passed: 6 tests, 0 failures.
- `swift test` passed: 528 tests, 1 skipped, 0 failures.
- `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency between the app’s supported languages, localization resources, and bundled language metadata.
  * Added validation to detect missing or obsolete localization files and keys.

* **Tests**
  * Expanded localization checks to verify supported languages match resource folders and app configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->